### PR TITLE
Feature renderer resource cache

### DIFF
--- a/demo/addons/gd_cubism/example/viewer.gd
+++ b/demo/addons/gd_cubism/example/viewer.gd
@@ -87,4 +87,4 @@ func _on_item_list_motion_item_selected(index):
 
 func _on_item_list_expression_item_selected(index):
     var expression_id = $UI/ItemListExpression.get_item_text(index)
-    cubism_model.set_expression(expression_id)
+    cubism_model.start_expression(expression_id)

--- a/src/gd_cubism_user_model.hpp
+++ b/src/gd_cubism_user_model.hpp
@@ -123,13 +123,13 @@ public:
     Array get_part_opacity() const;
 
     void set_shader(const GDCubismShader e, Ref<Shader> shader) { this->ary_shader[e] = shader; }
-    Ref<Shader> get_shader(const GDCubismShader e) { return this->ary_shader[e]; }
+    Ref<Shader> get_shader(const GDCubismShader e) const { return this->ary_shader[e]; }
     void set_shader_mix(Ref<Shader> shader) { this->set_shader(GD_CUBISM_SHADER_NORM_MIX, shader); }
-    Ref<Shader> get_shader_mix() { return this->get_shader(GD_CUBISM_SHADER_NORM_MIX); }
+    Ref<Shader> get_shader_mix() const { return this->get_shader(GD_CUBISM_SHADER_NORM_MIX); }
     void set_shader_mask_mix(Ref<Shader> shader) { this->set_shader(GD_CUBISM_SHADER_MASK_MIX, shader); }
-    Ref<Shader> get_shader_mask_mix() { return this->get_shader(GD_CUBISM_SHADER_MASK_MIX); }
+    Ref<Shader> get_shader_mask_mix() const { return this->get_shader(GD_CUBISM_SHADER_MASK_MIX); }
     void set_shader_mask_mix_inv(Ref<Shader> shader) { this->set_shader(GD_CUBISM_SHADER_MASK_MUL_INV, shader); }
-    Ref<Shader> get_shader_mask_mix_inv() { return this->get_shader(GD_CUBISM_SHADER_MASK_MUL_INV); }
+    Ref<Shader> get_shader_mask_mix_inv() const { return this->get_shader(GD_CUBISM_SHADER_MASK_MUL_INV); }
 
     static void on_motion_finished(Csm::ACubismMotion* motion);
 

--- a/src/private/internal_cubism_renderer_resource.hpp
+++ b/src/private/internal_cubism_renderer_resource.hpp
@@ -34,28 +34,28 @@ public:
     InternalCubismRendererResource(GDCubismUserModel *owner_viewport, Node *parent_node);
     ~InternalCubismRendererResource();
 
+    SubViewport* request_viewport();
+    MeshInstance2D* request_mesh_instance();
+
     void pro_proc(const Csm::csmInt32 viewport_count, const Csm::csmInt32 mesh_instance_count);
     void epi_proc();
 
-    void dispose_node();
+    void dispose_node(const bool node_release);
     void clear();
 
     // Shader
     Ref<Shader> get_shader(const GDCubismShader e) const { return this->ary_shader[e]; }
 
-    SubViewport* request_viewport() {
-        return memnew(SubViewport);
-    };
-    MeshInstance2D* request_mesh_instance() {
-        return memnew(MeshInstance2D);
-    }
-
 public:
-    GDCubismUserModel *_owner_viewport = nullptr;
-    Node *_parent_node = nullptr;
+    const GDCubismUserModel *_owner_viewport;
+    Node *_parent_node;
 
     Array ary_texture;
     Array ary_shader;
+    Csm::csmInt32 sub_viewport_counter;
+    TypedArray<SubViewport> ary_sub_viewport;
+    Csm::csmInt32 mesh_instance_counter;
+    TypedArray<MeshInstance2D> ary_mesh_instance;
 };
 
 


### PR DESCRIPTION
Stop recreating nodes and viewports every frame and cache them as arrays internally.
This will stabilize memory and object usage and improve performance.