### PR TITLE
誤字やリンクミスの修正、トラブルシューティングの追加

### DIFF
--- a/doc/BUILD.adoc
+++ b/doc/BUILD.adoc
@@ -41,7 +41,7 @@ git submodule update --init
 
 Live2D Cubism SDK for Nativeを取得してください。
 
-GDCubismが利用しているSDKバージョンは **Cubism 5 SDK for Native R2 beta2** です。
+GDCubismが利用しているSDKバージョンは **Cubism 5 SDK for Native R1 beta2** です。
 
 thirdpartyフォルダに展開した内容をそのまま配置してください。
 

--- a/doc/USAGE.adoc
+++ b/doc/USAGE.adoc
@@ -86,6 +86,15 @@ character.add_child(model)
 add_child(character)
 ----
 
+=== トラブルシューティング
+
+* モデルが正常に読み込まれない
+
+モデルのファイル名が日本語になっている場合は正常に読み込まれないため、Cubism Editorで出力したファイルの名前と、*.model3.json内の参照を上書きすることで正常に動作します。
+
+* まばたきが正常に行われない
+
+*.model3.json内のEyeBlinkのIdsが指定されていない可能性があります。設定して再出力するか、IdsにParamEyeLOpenとParamEyeROpenを追記してください。
 
 == API Reference
 
@@ -105,4 +114,4 @@ GDCubismにはさまざまなクラスが用意されています。使用方法
 **** link:API/ja/API_gd_cubism_motion_queue_entry_handle.ja.adoc[GDCubismMotionQueueEntryHandle]
 **** GDCubismValueAds
 ***** link:API/ja/API_gd_cubism_parameter.ja.adoc[GDCubismParameter]
-***** link:API/ja/API_gd_cubism_part_opaciry.ja.adoc[GDCubismPartOpacity]
+***** link:API/ja/API_gd_cubism_part_opacity.ja.adoc[GDCubismPartOpacity]

--- a/doc/USAGE.adoc
+++ b/doc/USAGE.adoc
@@ -27,7 +27,7 @@ link:USAGE.adoc[Japanese] / link:USAGE.en.adoc[English]
 
 == 使用方法
 
-GDExtensionのビルドが正常に完了したら、demo/addonsフォルダにある、gd_cubismフォルダを利用したいプロジェクトのaddonsにコピーしてください。
+GDExtensionのビルドが正常に完了したら、demo/addonsフォルダにあるgd_cubismフォルダを、利用したいプロジェクトのaddonsにコピーしてください。
 
 
 === 簡単な使い方（Editorから使う場合）

--- a/doc/USAGE.en.adoc
+++ b/doc/USAGE.en.adoc
@@ -88,6 +88,15 @@ character.add_child(model)
 add_child(character)
 ----
 
+=== Troubleshooting
+
+* Model does not load properly
+
+If the model file name is in Japanese, it will not load properly, so overwriting the file name output by the Cubism Editor and the reference in *.model3.json will work properly.
+
+* Blink does not occur normally
+
+It is possible that the Ids for EyeBlink in *.model3.json is not specified. Please set it and re-export, or add ParamEyeLOpen and ParamEyeROpen to Ids.
 
 == API Reference
 
@@ -107,4 +116,4 @@ GDCubism provides a variety of classes. Please refer to the document linked belo
 **** link:API_gd_cubism_motion_queue_entry_handle.ja.adoc[GDCubismMotionQueueEntryHandle]
 **** GDCubismValueAds
 ***** link:API_gd_cubism_parameter.ja.adoc[GDCubismParameter]
-***** link:API_gd_cubism_part_opaciry.ja.adoc[GDCubismPartOpacity]
+***** link:API_gd_cubism_part_opacity.ja.adoc[GDCubismPartOpacity]


### PR DESCRIPTION
英語訳は機械翻訳を利用しているため間違っている可能性があります。
以下の点を修正しました。
・API_gd_cubism_part_opacity.ja.adocのリンク切れを修正
・SDKバージョンの修正
・簡易的なトラブルシューティングの追加
