### PR TITLE
Add load parameters

### DIFF
--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -32,6 +32,8 @@ using namespace godot;
 // ------------------------------------------------------------------- class(s)
 GDCubismUserModel::GDCubismUserModel()
     : internal_model(nullptr)
+    , enable_load_expressions(true)
+    , enable_load_motions(true)
     , speed_scale(1.0)
     , auto_scale(true)
     , parameter_mode(ParameterMode::FULL_PARAMETER)
@@ -61,6 +63,16 @@ void GDCubismUserModel::_bind_methods() {
     ClassDB::bind_method(D_METHOD("set_assets", "assets"), &GDCubismUserModel::set_assets);
     ClassDB::bind_method(D_METHOD("get_assets"), &GDCubismUserModel::get_assets);
     ADD_PROPERTY(PropertyInfo(Variant::STRING, "assets", PROPERTY_HINT_FILE, "*.model3.json"), "set_assets", "get_assets");
+
+    // Enable Load Expressions
+    ClassDB::bind_method(D_METHOD("set_load_expressions", "enable"), &GDCubismUserModel::set_load_expressions);
+    ClassDB::bind_method(D_METHOD("get_load_expressions"), &GDCubismUserModel::get_load_expressions);
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "load_expressions"), "set_load_expressions", "get_load_expressions");
+
+    // Enable Load Motions
+    ClassDB::bind_method(D_METHOD("set_load_motions", "enable"), &GDCubismUserModel::set_load_motions);
+    ClassDB::bind_method(D_METHOD("get_load_motions"), &GDCubismUserModel::get_load_motions);
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "load_motions"), "set_load_motions", "get_load_motions");
 
     ClassDB::bind_method(D_METHOD("get_canvas_info"), &GDCubismUserModel::get_canvas_info);
 
@@ -245,6 +257,12 @@ void GDCubismUserModel::set_assets(const String assets) {
 String GDCubismUserModel::get_assets() const {
     return this->assets;
 }
+
+
+void GDCubismUserModel::set_load_expressions(const bool enable) { this->enable_load_expressions = enable; }
+bool GDCubismUserModel::get_load_expressions() const { return this->enable_load_expressions; }
+void GDCubismUserModel::set_load_motions(const bool enable) { this->enable_load_motions = enable; }
+bool GDCubismUserModel::get_load_motions() const { return this->enable_load_motions; }
 
 
 Dictionary GDCubismUserModel::get_canvas_info() const {

--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -343,6 +343,7 @@ bool GDCubismUserModel::get_auto_scale() const {
 
 Dictionary GDCubismUserModel::get_motions() const {
     ERR_FAIL_COND_V(this->is_initialized() == false, Dictionary());
+    if(this->enable_load_motions == false) return Dictionary();
 
     Csm::ICubismModelSetting* setting = this->internal_model->_model_setting;
 
@@ -410,6 +411,7 @@ void GDCubismUserModel::stop_motion() {
 
 Array GDCubismUserModel::get_expressions() const {
     ERR_FAIL_COND_V(this->is_initialized() == false, Array());
+    if(this->enable_load_expressions == false) return Array();
 
     Csm::ICubismModelSetting* setting = this->internal_model->_model_setting;
 
@@ -550,21 +552,24 @@ void GDCubismUserModel::setup_property() {
     Csm::ICubismModelSetting* setting = this->internal_model->_model_setting;
 
     // Property - Expression
-    this->dict_anim_expression.Clear();
-    for(Csm::csmInt32 i = 0; i < setting->GetExpressionCount(); i++) {
-        const Csm::csmChar* expression_id = setting->GetExpressionName(i);
-        anim_expression anim_e(expression_id);
+    if(this->enable_load_expressions == true) {
+        for(Csm::csmInt32 i = 0; i < setting->GetExpressionCount(); i++) {
+            const Csm::csmChar* expression_id = setting->GetExpressionName(i);
+            anim_expression anim_e(expression_id);
 
-        this->dict_anim_expression[anim_e.to_string()] = anim_e;
+            this->dict_anim_expression[anim_e.to_string()] = anim_e;
+        }
     }
 
     // Property - Motion
-    for(Csm::csmInt32 i = 0; i < setting->GetMotionGroupCount(); i++) {
-        const Csm::csmChar* group = setting->GetMotionGroupName(i);
-        for(Csm::csmInt32 no = 0; no < setting->GetMotionCount(group); no++) {
-            anim_motion anim_m(group, no);
+    if(this->enable_load_motions == true) {
+        for(Csm::csmInt32 i = 0; i < setting->GetMotionGroupCount(); i++) {
+            const Csm::csmChar* group = setting->GetMotionGroupName(i);
+            for(Csm::csmInt32 no = 0; no < setting->GetMotionCount(group); no++) {
+                anim_motion anim_m(group, no);
 
-            this->dict_anim_motion[anim_m.to_string()] = anim_m;
+                this->dict_anim_motion[anim_m.to_string()] = anim_m;
+            }
         }
     }
 }
@@ -714,23 +719,27 @@ void GDCubismUserModel::_get_property_list(List<godot::PropertyInfo> *p_list) {
 
     // Property - Expression
     ary_enum.clear();
-    for(Csm::csmInt32 i = 0; i < setting->GetExpressionCount(); i++) {
-        const Csm::csmChar* expression_id = setting->GetExpressionName(i);
-        anim_expression anim_e(expression_id);
+    if(this->enable_load_expressions == true) {
+        for(Csm::csmInt32 i = 0; i < setting->GetExpressionCount(); i++) {
+            const Csm::csmChar* expression_id = setting->GetExpressionName(i);
+            anim_expression anim_e(expression_id);
 
-        ary_enum.append(anim_e.to_string());
+            ary_enum.append(anim_e.to_string());
+        }
     }
 
     p_list->push_back(PropertyInfo(Variant::STRING, PROP_ANIM_EXPRESSION, PROPERTY_HINT_ENUM, String(",").join(ary_enum)));
 
     // Property - Motion
     ary_enum.clear();
-    for(Csm::csmInt32 i = 0; i < setting->GetMotionGroupCount(); i++) {
-        const Csm::csmChar* group = setting->GetMotionGroupName(i);
-        for(Csm::csmInt32 no = 0; no < setting->GetMotionCount(group); no++) {
-            anim_motion anim_m(group, no);
+    if(this->enable_load_motions == true) {
+        for(Csm::csmInt32 i = 0; i < setting->GetMotionGroupCount(); i++) {
+            const Csm::csmChar* group = setting->GetMotionGroupName(i);
+            for(Csm::csmInt32 no = 0; no < setting->GetMotionCount(group); no++) {
+                anim_motion anim_m(group, no);
 
-            ary_enum.append(anim_m.to_string());
+                ary_enum.append(anim_m.to_string());
+            }
         }
     }
 

--- a/src/gd_cubism_user_model.hpp
+++ b/src/gd_cubism_user_model.hpp
@@ -104,6 +104,9 @@ public:
 
     String assets;
     InternalCubismUserModel *internal_model;
+    bool enable_load_expressions;
+    bool enable_load_motions;
+
     float speed_scale;
     bool auto_scale;
     ParameterMode parameter_mode;
@@ -133,6 +136,11 @@ public:
 
     void set_assets(const String assets);
     String get_assets() const;
+
+    void set_load_expressions(const bool enable);
+    bool get_load_expressions() const;
+    void set_load_motions(const bool enable);
+    bool get_load_motions() const;
 
     Dictionary get_canvas_info() const;
 

--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -71,7 +71,10 @@ bool InternalCubismUserModel::model_load(const String &model_pathname) {
     }
 
     // Expression
-    this->expression_load();
+    if(this->_owner_viewport->enable_load_expressions == true) {
+        this->expression_load();
+    }
+
     // Physics
     this->physics_load();
     // Pose
@@ -105,7 +108,10 @@ bool InternalCubismUserModel::model_load(const String &model_pathname) {
     this->_model->SaveParameters();
 
     // Motion
-    this->motion_load();
+    if(this->_owner_viewport->enable_load_motions== true) {
+        this->motion_load();
+    }
+
     // GDCubismEffect
     this->effect_init();
 


### PR DESCRIPTION
In order to address the following issue, we have made it possible to exclude ‘expression’ and ‘motion’ during the loading process. For more details, please refer to the following link: GitHub Issue.　

https://github.com/MizunagiKB/gd_cubism/issues/52