### PR TITLE
Add mipmap support for displaying high-res texture atlas smoothly

### DIFF
--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask.gdshader
@@ -5,7 +5,7 @@ shader_type canvas_item;
 render_mode blend_mix, unshaded;
 
 uniform vec4 channel;
-uniform sampler2D tex_main;
+uniform sampler2D tex_main : filter_linear_mipmap;
 
 void vertex() {
     UV.y = 1.0 - UV.y;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add.gdshader
@@ -8,8 +8,8 @@ uniform vec4 color_base;
 uniform vec4 color_screen;
 uniform vec4 color_multiply;
 uniform vec4 channel;
-uniform sampler2D tex_main;
-uniform sampler2D tex_mask;
+uniform sampler2D tex_main : filter_linear_mipmap;
+uniform sampler2D tex_mask : filter_linear_mipmap;
 
 void vertex() {
     UV.y = 1.0 - UV.y;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add_inv.gdshader
@@ -8,8 +8,8 @@ uniform vec4 color_base;
 uniform vec4 color_screen;
 uniform vec4 color_multiply;
 uniform vec4 channel;
-uniform sampler2D tex_main;
-uniform sampler2D tex_mask;
+uniform sampler2D tex_main : filter_linear_mipmap;
+uniform sampler2D tex_mask : filter_linear_mipmap;
 
 void vertex() {
     UV.y = 1.0 - UV.y;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix.gdshader
@@ -8,8 +8,8 @@ uniform vec4 color_base;
 uniform vec4 color_screen;
 uniform vec4 color_multiply;
 uniform vec4 channel;
-uniform sampler2D tex_main;
-uniform sampler2D tex_mask;
+uniform sampler2D tex_main : filter_linear_mipmap;
+uniform sampler2D tex_mask : filter_linear_mipmap;
 
 void vertex() {
     UV.y = 1.0 - UV.y;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix_inv.gdshader
@@ -8,8 +8,8 @@ uniform vec4 color_base;
 uniform vec4 color_screen;
 uniform vec4 color_multiply;
 uniform vec4 channel;
-uniform sampler2D tex_main;
-uniform sampler2D tex_mask;
+uniform sampler2D tex_main : filter_linear_mipmap;
+uniform sampler2D tex_mask : filter_linear_mipmap;
 
 void vertex() {
     UV.y = 1.0 - UV.y;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul.gdshader
@@ -8,8 +8,8 @@ uniform vec4 color_base;
 uniform vec4 color_screen;
 uniform vec4 color_multiply;
 uniform vec4 channel;
-uniform sampler2D tex_main;
-uniform sampler2D tex_mask;
+uniform sampler2D tex_main : filter_linear_mipmap;
+uniform sampler2D tex_mask : filter_linear_mipmap;
 
 void vertex() {
     UV.y = 1.0 - UV.y;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul_inv.gdshader
@@ -8,8 +8,8 @@ uniform vec4 color_base;
 uniform vec4 color_screen;
 uniform vec4 color_multiply;
 uniform vec4 channel;
-uniform sampler2D tex_main;
-uniform sampler2D tex_mask;
+uniform sampler2D tex_main : filter_linear_mipmap;
+uniform sampler2D tex_mask : filter_linear_mipmap;
 
 void vertex() {
     UV.y = 1.0 - UV.y;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_norm_add.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_norm_add.gdshader
@@ -8,7 +8,7 @@ uniform vec4 color_base;
 uniform vec4 color_screen;
 uniform vec4 color_multiply;
 uniform vec4 channel;
-uniform sampler2D tex_main;
+uniform sampler2D tex_main : filter_linear_mipmap;
 
 void vertex() {
     UV.y = 1.0 - UV.y;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mix.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mix.gdshader
@@ -8,7 +8,7 @@ uniform vec4 color_base;
 uniform vec4 color_screen;
 uniform vec4 color_multiply;
 uniform vec4 channel;
-uniform sampler2D tex_main;
+uniform sampler2D tex_main : filter_linear_mipmap;
 
 void vertex() {
     UV.y = 1.0 - UV.y;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mul.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mul.gdshader
@@ -8,7 +8,7 @@ uniform vec4 color_base;
 uniform vec4 color_screen;
 uniform vec4 color_multiply;
 uniform vec4 channel;
-uniform sampler2D tex_main;
+uniform sampler2D tex_main : filter_linear_mipmap;
 
 void vertex() {
     UV.y = 1.0 - UV.y;


### PR DESCRIPTION
just a tiny fix for displaying high resolution live2d models correctly
---EDIT---
For testing this, mipmap generation in the texture import options should be toggled on.

------Before---
![image](https://github.com/MizunagiKB/gd_cubism/assets/33864304/a4c6a74a-cd2b-42d1-8137-30ccd81c30df)

------After-----
![image](https://github.com/MizunagiKB/gd_cubism/assets/33864304/df03577b-1c61-4b75-a508-b31cc1f689a7)
