### PR TITLE
Modified to explicitly specify access modifiers.

### DIFF
--- a/src/gd_cubism_motion_entry.hpp
+++ b/src/gd_cubism_motion_entry.hpp
@@ -29,6 +29,7 @@ class GDCubismMotionQueueEntryHandle : public Resource {
     GDCLASS(GDCubismMotionQueueEntryHandle, Resource)
     friend GDCubismUserModel;
 
+public:
     enum HandleError {
         OK = godot::Error::OK,
         FAILED = godot::Error::FAILED


### PR DESCRIPTION
Access modifier was inadvertently set to private for the enum type `HandleError` within the class `GDCubismMotionQueueEntryHandle` due to unspecified access modifier.

Addressed the issue related to this bug.
https://github.com/MizunagiKB/gd_cubism/issues/67