### PR TITLE
Usage file: Fix path to image

### DIFF
--- a/docs-src/modules/ROOT/pages/en/usage.adoc
+++ b/docs-src/modules/ROOT/pages/en/usage.adoc
@@ -40,7 +40,7 @@ Describes how to import a Live2D model and view it in _Sprite2D_.
 
 Please arrange the nodes in the same way while referring to the figure below.
 
-image::usage_simple_01.png[fig01,256]
+image::../../images/usage_simple_01.png[fig01,256]
 
 
 ==== Loading Live2D Models
@@ -50,14 +50,14 @@ Select _GDCubismUserModel_ from the node list and press the file selection butto
  +
 A file selection dialog will appear, from which you can select any *.model3.json file.
 
-image::usage_simple_02.png[fig02,256]
+image::../../images/usage_simple_02.png[fig02,256]
 
 
 ==== Are you seeing a Live2D model?
 
 Once the Live2D model is loaded correctly, the preview screen displays the Live2D model.
 
-image::usage_simple_03.png[fig03,256]
+image::../../images/usage_simple_03.png[fig03,256]
 
 
 ==== Assign to Sprite2D texture
@@ -65,15 +65,15 @@ image::usage_simple_03.png[fig03,256]
 Then select the _Sprite2D_ node to open the Texture item. +
 When you select ''New ViewportTexture'' from the list, a dialog to select _Viewport_ will appear, select _GDCubismUserModel_.
 
-image::usage_simple_04.png[fig04,256]
+image::../../images/usage_simple_04.png[fig04,256]
 
 The Live2D model is displayed in the Texture field.
 
-image::usage_simple_05.png[fig05,256]
+image::../../images/usage_simple_05.png[fig05,256]
 
 The Live2D model is also displayed at the _Sprite2D_ position.
 
-image::usage_simple_06.png[fig06,512]
+image::../../images/usage_simple_06.png[fig06,512]
 
 
 === Troubleshooting
@@ -92,7 +92,7 @@ Mipmap has been enabled for shaders from version 0.5 onwards.
 
 If you wish to enable it, please re-import the texture being used in Live2D with Mipmap enabled.
 
-image::usage_mipmap_01.png[mipmap01,256]
+image::../../images/usage_mipmap_01.png[mipmap01,256]
 
 The effect of Mipmap is quite significant, however, depending on the image, it may appear blurry.
 
@@ -102,7 +102,7 @@ image::usage_mipmap_02a.jpg[mipmap02a,256]
 
 With Mipmap Application
 
-image::usage_mipmap_02b.jpg[mipmap02b,256]
+image::../../images/usage_mipmap_02b.jpg[mipmap02b,256]
 
 ==== Live2D Models Not Displayed When Exporting Projects
 

--- a/docs-src/modules/ROOT/pages/en/usage.adoc
+++ b/docs-src/modules/ROOT/pages/en/usage.adoc
@@ -98,7 +98,7 @@ The effect of Mipmap is quite significant, however, depending on the image, it m
 
 Without Mipmap Application
 
-image::usage_mipmap_02a.jpg[mipmap02a,256]
+image::../../images/usage_mipmap_02a.jpg[mipmap02a,256]
 
 With Mipmap Application
 

--- a/docs-src/modules/ROOT/pages/ja/usage.adoc
+++ b/docs-src/modules/ROOT/pages/ja/usage.adoc
@@ -40,7 +40,7 @@ Live2Dモデルを読み込んで _Sprite2D_ で表示を行う方法につい�
 
 以下の図を参考にしながら同じ様にノードを配置してください。
 
-image::usage_simple_01.png[fig01,256]
+image::../../images/usage_simple_01.png[fig01,256]
 
 
 ==== Live2Dモデルの読込
@@ -48,14 +48,14 @@ image::usage_simple_01.png[fig01,256]
 ノード一覧から _GDCubismUserModel_ を選択して、Assets項目の右にあるファイル選択ボタンを押してください。 +
 ファイル選択ダイアログが表示されますので、そこから任意の *.model3.json ファイルを選択します。
 
-image::usage_simple_02.png[fig02,256]
+image::../../images/usage_simple_02.png[fig02,256]
 
 
 ==== プレビュー画面にLive2Dモデルが表示されているのを確認
 
 Live2Dモデルが正しく読み込まれましたら、プレビュー画面にLive2Dモデルが表示されます。
 
-image::usage_simple_03.png[fig03,256]
+image::../../images/usage_simple_03.png[fig03,256]
 
 
 ==== スプライトにLive2Dモデルを表示
@@ -63,15 +63,15 @@ image::usage_simple_03.png[fig03,256]
 次に _Sprite2D_ ノードを選択して、Texture項目を開きます。 +
 一覧から ```New ViewportTexture``` を選択すると _Viewport_ を選択するダイアログが表示されますので、 _GDCubismUserModel_ を選択します。
 
-image::usage_simple_04.png[fig04,256]
+image::../../images/usage_simple_04.png[fig04,256]
 
 Texture欄にLive2Dモデルが表示されます。
 
-image::usage_simple_05.png[fig05,256]
+image::../../images/usage_simple_05.png[fig05,256]
 
 _Sprite2D_ の位置にもLive2Dモデルが表示されます。
 
-image::usage_simple_06.png[fig06,512]
+image::../../images/usage_simple_06.png[fig06,512]
 
 
 === トラブルシューティング
@@ -90,17 +90,17 @@ image::usage_simple_06.png[fig06,512]
 
 有効にする場合は、Live2Dで使用しているテクスチャを Mipmap を有効にして再インポートを行なってください。
 
-image::usage_mipmap_01.png[mipmap01,256]
+image::../../images/usage_mipmap_01.png[mipmap01,256]
 
 Mipmapの効果はかなり高いですが、絵によってはぼやけた感じとなる場合があります。
 
 Mipmap適用なし
 
-image::usage_mipmap_02a.jpg[mipmap02a,256]
+image::../../images/usage_mipmap_02a.jpg[mipmap02a,256]
 
 Mipmap適用あり
 
-image::usage_mipmap_02b.jpg[mipmap02b,256]
+image::../../images/usage_mipmap_02b.jpg[mipmap02b,256]
 
 ==== プロジェクトを Export すると Live2D モデルが表示されない
 


### PR DESCRIPTION
### What was done.
Changed the path to the image in the JP / EN usage.adoc.

### How it was tested
Previewing images now works.

Before:
![image](https://github.com/MizunagiKB/gd_cubism/assets/25706165/ece852e5-0f65-4d4e-b8a9-dcf6aac1cfbd)

Now:
![image](https://github.com/MizunagiKB/gd_cubism/assets/25706165/c29a5364-899b-4bba-ae4d-77654c6ca3d4)

### Comment to repository owner
[DeepL] お疲れ様でした。画像を反映するようにパスを編集しましたが、おそらく画像は別のフォルダに属しています。
Thank you for your work. I have edited the path to reflect the image, but perhaps the image belongs in a different folder.