### PR TITLE
add scons option for Windows, vsproj=yes

### DIFF
--- a/docs-src/modules/ROOT/pages/en/build.adoc
+++ b/docs-src/modules/ROOT/pages/en/build.adoc
@@ -163,10 +163,10 @@ link:https://docs.godotengine.org/en/stable/contributing/development/compiling/c
 
 When ready, run the build with the following command.
 
-[source]
+[source, console]
 --
-scons platform=windows arch=x86_64 target=template_debug
-scons platform=windows arch=x86_64 target=template_release
+scons platform=windows vsproj=yes arch=x86_64 target=template_debug
+scons platform=windows vsproj=yes arch=x86_64 target=template_release
 --
 
 When the build is completed, the following files will be generated under _demo/addons/gd_cubism/bin_.

--- a/docs-src/modules/ROOT/pages/ja/build.adoc
+++ b/docs-src/modules/ROOT/pages/ja/build.adoc
@@ -167,8 +167,8 @@ link:https://docs.godotengine.org/en/stable/contributing/development/compiling/c
 
 [source, console]
 --
-scons platform=windows arch=x86_64 target=template_debug
-scons platform=windows arch=x86_64 target=template_release
+scons platform=windows vsproj=yes arch=x86_64 target=template_debug
+scons platform=windows vsproj=yes arch=x86_64 target=template_release
 --
 
 ビルドが完了すると以下のファイルが _demo/addons/gd_cubism/bin_ 以下に生成されます。


### PR DESCRIPTION
Instructions to use Visual Studio for the SCons arguments when building the Windows version have been added.

A branch named fix_vsproj_build has been created, and the command line instructions for the build process are as follows:

```
scons platform=windows vsproj=yes arch=x86_64 target=template_debug
scons platform=windows vsproj=yes arch=x86_64 target=template_release

```

After verifying the operation locally, it will be merged into the update_v0_6_1 branch and is scheduled to be released as v0.6.1.