### PR TITLE
Fixed a bug where the mask could not be referenced correctly.

### DIFF
--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add.gdshader
@@ -11,11 +11,37 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform vec2 mask_adjust_pos;
-uniform float mask_adjust_scale;
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
 
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
@@ -27,8 +53,8 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    float screen_scale = 1.0 / mask_adjust_scale;
-    vec4 clip_mask = texture(tex_mask, ((SCREEN_UV - 0.5) * screen_scale) + 0.50 ) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask.rgb = color_for_mask.rgb * mask_val;
     COLOR = vec4(color_for_mask.rgb, 0.0);

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add_inv.gdshader
@@ -11,11 +11,37 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform vec2 mask_adjust_pos;
-uniform float mask_adjust_scale;
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
 
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
@@ -27,8 +53,8 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    float screen_scale = 1.0 / mask_adjust_scale;
-    vec4 clip_mask = texture(tex_mask, ((SCREEN_UV - 0.5) * screen_scale) + 0.50 ) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask.rgb = color_for_mask.rgb * (1.0 - mask_val);
     COLOR = vec4(color_for_mask.rgb, 0.0);

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix.gdshader
@@ -11,11 +11,37 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform vec2 mask_adjust_pos;
-uniform float mask_adjust_scale;
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
 
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
@@ -27,8 +53,8 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    float screen_scale = 1.0 / mask_adjust_scale;
-    vec4 clip_mask = texture(tex_mask, ((SCREEN_UV - 0.5) * screen_scale) + 0.50 ) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * mask_val;
     COLOR = color_for_mask;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix_inv.gdshader
@@ -11,11 +11,37 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform vec2 mask_adjust_pos;
-uniform float mask_adjust_scale;
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
 
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
@@ -27,8 +53,8 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    float screen_scale = 1.0 / mask_adjust_scale;
-    vec4 clip_mask = texture(tex_mask, ((SCREEN_UV - 0.5) * screen_scale) + 0.50 ) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * (1.0 - mask_val);
     COLOR = color_for_mask;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul.gdshader
@@ -11,11 +11,37 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform vec2 mask_adjust_pos;
-uniform float mask_adjust_scale;
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
 
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
@@ -27,8 +53,8 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    float screen_scale = 1.0 / mask_adjust_scale;
-    vec4 clip_mask = texture(tex_mask, ((SCREEN_UV - 0.5) * screen_scale) + 0.50 ) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * mask_val;
     COLOR = vec4(

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul_inv.gdshader
@@ -11,11 +11,37 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform vec2 mask_adjust_pos;
-uniform float mask_adjust_scale;
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
 
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
@@ -27,8 +53,8 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    float screen_scale = 1.0 / mask_adjust_scale;
-    vec4 clip_mask = texture(tex_mask, ((SCREEN_UV - 0.5) * screen_scale) + 0.50 ) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * (1.0 - mask_val);
     COLOR = vec4(

--- a/docs-site/antora-playbook.yml
+++ b/docs-site/antora-playbook.yml
@@ -5,7 +5,7 @@ site:
 content:
   sources:
     - url: https://github.com/MizunagiKB/gd_cubism.git
-      branches: 0.6
+      branches: [0.6, 0.7]
       start_path: docs-src
 ui:
   bundle:

--- a/src/private/internal_cubism_renderer_2d.hpp
+++ b/src/private/internal_cubism_renderer_2d.hpp
@@ -39,15 +39,19 @@ public:
 
 private:
     Ref<ShaderMaterial> make_ShaderMaterial(const Csm::CubismModel *model, const Csm::csmInt32 index, const InternalCubismRendererResource &res) const;
+    void make_ArrayMesh_prepare(
+        const Csm::CubismModel *model,
+        const float &adjust_scale,
+        const Vector2 &adjust_pos,
+        InternalCubismRendererResource &res);
+
     Ref<ArrayMesh> make_ArrayMesh(
         const Csm::CubismModel *model,
-        const Vector2 vct_canvas_size,
-        const Vector2 vct_mask_size,
         const Csm::csmInt32 index,
-        const bool auto_scale,
         const float adjust_scale,
         const Vector2 &adjust_pos,
-        const bool makemask) const;
+        const bool makemask,
+        const InternalCubismRendererResource &res) const;
 
     void update_mask(SubViewport *viewport, const Csm::csmInt32 index, InternalCubismRendererResource &res);
 

--- a/src/private/internal_cubism_renderer_resource.hpp
+++ b/src/private/internal_cubism_renderer_resource.hpp
@@ -64,6 +64,15 @@ public:
     // Adjust Parameters
     Vector2 adjust_pos;
     float adjust_scale;
+
+    // Render parameters
+    Vector2i vct_canvas_size;
+    Vector2i vct_mask_size;
+    float RATIO;
+    float CALCULATED_PPUNIT_C;
+    float CALCULATED_PPUNIT_M;
+    Vector2 CALCULATED_ORIGIN_C;
+    Vector2 CALCULATED_ORIGIN_M;
 };
 
 


### PR DESCRIPTION
I have organized the mathematical expressions in `internal_cubism_renderer_2d.cpp` and modified the code so that the specified parameter results in the same outcome as 0.6.

As a result, the method of rendering masks has changed depending on whether `auto_scale` is enabled or disabled.

**When `auto_scale` is enabled:**
- The mask is rendered ignoring the `adjust_scale` information.
- This ensures that the quality of the mask texture is maintained even if a reduction is specified by `adjust_scale`.

**When `auto_scale` is disabled:**
- The mask is rendered referencing the `adjust_scale` information.
- This ensures that the mask is positioned accurately.

The optimal result depends on the Live2D model you wish to render.
