### PR TITLE
Fix bug for dark problem when parts are semi-transparent

### DIFF
--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -143,7 +143,7 @@ bool InternalCubismUserModel::model_load(const String &model_pathname) {
             renderer->calc_mesh_instance_count()
         );
 
-        renderer->IsPremultipliedAlpha(true);
+        renderer->IsPremultipliedAlpha(false);
         renderer->DrawModel();
         renderer->update(this->_renderer_resource, false, true);
 
@@ -243,7 +243,7 @@ void InternalCubismUserModel::update_node() {
         renderer->calc_mesh_instance_count()
     );
 
-    renderer->IsPremultipliedAlpha(true);
+    renderer->IsPremultipliedAlpha(false);
     renderer->DrawModel();
     renderer->update(this->_renderer_resource);
 


### PR DESCRIPTION
As mentioned in #113 , this problem was caused by `IsPremultipliedAlpha` setting in `gd_cubsim`.
From the code of `CubsimNativeFramework(CubismRenderer.cpp)`, we can know that if it is true, the opacity will be pre-multiplied to RGB channel in return value, which is used as `color_base` in shaders of `gd_cubsim`.
```
CubismRenderer::CubismTextureColor CubismRenderer::GetModelColorWithOpacity(const csmFloat32 opacity) const
{
    CubismTextureColor modelColorRGBA = GetModelColor();
    modelColorRGBA.A *= opacity;
    if (IsPremultipliedAlpha())
    {
        modelColorRGBA.R *= modelColorRGBA.A;
        modelColorRGBA.G *= modelColorRGBA.A;
        modelColorRGBA.B *= modelColorRGBA.A;
    }
    return modelColorRGBA;
}
```

However, the shaders in `gd_cubsim` also multiple the alpha, like this:

```
void fragment() {
    vec4 color_tex = texture(tex_main, UV);
    color_tex.rgb = color_tex.rgb * color_multiply.rgb;

    // premul alpha
    color_tex.rgb = (color_tex.rgb + color_screen.rgb) - (color_tex.rgb * color_screen.rgb);
    vec4 color = color_tex * color_base;
    COLOR = vec4(color.rgb * color.a, color.a);   //  <- here
}
```

As a result, the double multiplication leads to darker image when parts are semi-transparent. Considering the readability of shaders, which means that the blend mode should be consistent with the shader's code, I chose to change the c++ code. Now,  `IsPremultipliedAlpha` is set to `false`.

Hope this helps.
Thanks for your work!  d(`･∀･)b