### PR TITLE
Improve allocation stability

### DIFF
--- a/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mix.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mix.gdshader
@@ -21,5 +21,5 @@ void fragment() {
     // premul alpha
     color_tex.rgb = (color_tex.rgb + color_screen.rgb) - (color_tex.rgb * color_screen.rgb);
     vec4 color = color_tex * color_base;
-    COLOR = vec4(color.rgb * color.a, color.a);
+    COLOR *= vec4(color.rgb * color.a, color.a);
 }

--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -312,6 +312,10 @@ void GDCubismUserModel::clear() {
         this->internal_model = nullptr;
     }
 
+    for (int i = 0; i < this->get_child_count(); i++) {
+        this->get_child(i)->queue_free();
+    }
+
     this->setup_property();
     this->notify_property_list_changed();
 }

--- a/src/gd_cubism_user_model.hpp
+++ b/src/gd_cubism_user_model.hpp
@@ -150,7 +150,7 @@ public:
     Dictionary get_canvas_info() const;
 
     bool is_initialized() const;
-    void clear();
+    void load_model();
 
     void set_parameter_mode(const ParameterMode value);
     GDCubismUserModel::ParameterMode get_parameter_mode() const;

--- a/src/private/internal_cubism_renderer_2d.cpp
+++ b/src/private/internal_cubism_renderer_2d.cpp
@@ -330,8 +330,9 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res)
                 }
             }
 
-            res._parent_node->call_deferred("add_child", viewport);
+            res._parent_node->add_child(viewport);
 
+            mat->set_shader_parameter("tex_mask", viewport->get_texture());
             mat->set_shader_parameter("auto_scale", res._owner_viewport->auto_scale);
             mat->set_shader_parameter("canvas_size", Vector2(res.vct_canvas_size));
             mat->set_shader_parameter("mask_size", Vector2(res.vct_mask_size));
@@ -343,22 +344,11 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res)
             res.dict_mask[node_name] = masks;
 
             node->set_meta("viewport", viewport);
-
-            // textures from viewports can not be accessed until after the viewport is ready
-            node->connect("ready", callable_mp_static(&InternalCubismRenderer2D::ready_mask).bind(node));
         }
 
         res.dict_mesh[node_name] = node;
-        res._parent_node->call_deferred("add_child", node);
-        
-        
+        res._parent_node->add_child(node);
     }
-}
-
-void InternalCubismRenderer2D::ready_mask(const MeshInstance2D *node) {
-    SubViewport* viewport = Object::cast_to<SubViewport>(node->get_meta("viewport"));
-    Ref<ShaderMaterial> mat = node->get_material();
-    mat->set_shader_parameter("tex_mask", viewport->get_texture());
 }
 
 void InternalCubismRenderer2D::Initialize(Csm::CubismModel *model, Csm::csmInt32 maskBufferCount)

--- a/src/private/internal_cubism_renderer_2d.cpp
+++ b/src/private/internal_cubism_renderer_2d.cpp
@@ -40,86 +40,13 @@ InternalCubismRenderer2D::~InternalCubismRenderer2D()
 {
 }
 
-Ref<ShaderMaterial> InternalCubismRenderer2D::make_ShaderMaterial(const Csm::CubismModel *model, const Csm::csmInt32 index, const InternalCubismRendererResource &res) const
+void InternalCubismRenderer2D::update_material(const Csm::CubismModel *model, const Csm::csmInt32 index, const Ref<ShaderMaterial> mat) const
 {
-    Ref<ShaderMaterial> mat;
-    mat.instantiate();
-
-    GDCubismShader e = GD_CUBISM_SHADER_NORM_MIX;
-
-    if (model->GetDrawableMaskCounts()[index] == 0)
-    {
-        switch (model->GetDrawableBlendMode(index))
-        {
-        case CubismBlendMode_Additive:
-            e = GD_CUBISM_SHADER_NORM_ADD;
-            break;
-        case CubismBlendMode_Normal:
-            e = GD_CUBISM_SHADER_NORM_MIX;
-            break;
-        case CubismBlendMode_Multiplicative:
-            e = GD_CUBISM_SHADER_NORM_MUL;
-            break;
-        default:
-            e = GD_CUBISM_SHADER_NORM_MIX;
-            break;
-        }
-    }
-    else
-    {
-        if (model->GetDrawableInvertedMask(index) == false)
-        {
-            switch (model->GetDrawableBlendMode(index))
-            {
-            case CubismBlendMode_Additive:
-                e = GD_CUBISM_SHADER_MASK_ADD;
-                break;
-            case CubismBlendMode_Normal:
-                e = GD_CUBISM_SHADER_MASK_MIX;
-                break;
-            case CubismBlendMode_Multiplicative:
-                e = GD_CUBISM_SHADER_MASK_MUL;
-                break;
-            default:
-                e = GD_CUBISM_SHADER_MASK_MIX;
-                break;
-            }
-        }
-        else
-        {
-            switch (model->GetDrawableBlendMode(index))
-            {
-            case CubismBlendMode_Additive:
-                e = GD_CUBISM_SHADER_MASK_ADD_INV;
-                break;
-            case CubismBlendMode_Normal:
-                e = GD_CUBISM_SHADER_MASK_MIX_INV;
-                break;
-            case CubismBlendMode_Multiplicative:
-                e = GD_CUBISM_SHADER_MASK_MUL_INV;
-                break;
-            default:
-                e = GD_CUBISM_SHADER_MASK_MIX_INV;
-                break;
-            }
-        }
-    }
-
-    Ref<Shader> shader = res._owner_viewport->get_shader(e);
-    if (shader.is_null())
-        shader = res.get_shader(e);
-
-    mat->set_shader(shader);
-
     const CubismTextureColor color_base = this->GetModelColorWithOpacity(model->GetDrawableOpacity(index));
 
     mat->set_shader_parameter("color_base", Vector4(color_base.R, color_base.G, color_base.B, color_base.A));
     mat->set_shader_parameter("color_screen", make_vector4(model->GetDrawableScreenColor(index)));
     mat->set_shader_parameter("color_multiply", make_vector4(model->GetDrawableMultiplyColor(index)));
-    mat->set_shader_parameter("channel", Vector4(0.0, 0.0, 0.0, 1.0));
-    mat->set_shader_parameter("tex_main", res.ary_texture[model->GetDrawableTextureIndex(index)]);
-
-    return mat;
 }
 
 void InternalCubismRenderer2D::make_ArrayMesh_prepare(
@@ -130,6 +57,7 @@ void InternalCubismRenderer2D::make_ArrayMesh_prepare(
     const Vector2 vct_origin = this->get_origin(model);
     const float ppunit = this->get_ppunit(model);
 
+    res._owner_viewport->set_size(vct_size);
     res.vct_canvas_size = res._owner_viewport->get_size();
 
     if (res._owner_viewport->mask_viewport_size.x > 0 && res._owner_viewport->mask_viewport_size.y > 0)
@@ -161,13 +89,18 @@ void InternalCubismRenderer2D::make_ArrayMesh_prepare(
     }
 }
 
-Ref<ArrayMesh> InternalCubismRenderer2D::make_ArrayMesh(
+void InternalCubismRenderer2D::update_mesh(
     const Csm::CubismModel *model,
     const Csm::csmInt32 index,
     const bool maskmode,
-    const InternalCubismRendererResource &res) const
+    const InternalCubismRendererResource &res,
+    const Ref<ArrayMesh> ary_mesh
+) const
 {
     const Vector2 adjust_pos = res.adjust_pos;
+
+    ary_mesh->clear_surfaces();
+
     Array ary;
 
     ary.resize(Mesh::ARRAY_MAX);
@@ -208,12 +141,7 @@ Ref<ArrayMesh> InternalCubismRenderer2D::make_ArrayMesh(
         model->GetDrawableVertexIndices(index),
         model->GetDrawableVertexIndexCount(index));
 
-    Ref<ArrayMesh> ary_mesh;
-
-    ary_mesh.instantiate();
     ary_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, ary);
-
-    return ary_mesh;
 }
 
 Csm::csmInt32 InternalCubismRenderer2D::calc_viewport_count() const
@@ -277,36 +205,6 @@ float InternalCubismRenderer2D::get_ppunit(const Csm::CubismModel *model) const
     return ppunit;
 }
 
-void InternalCubismRenderer2D::update_mask(SubViewport *viewport, const Csm::csmInt32 index, InternalCubismRendererResource &res)
-{
-    CubismModel *model = this->GetModel();
-
-    Ref<ShaderMaterial> mat;
-    mat.instantiate();
-
-    Ref<Shader> shader = res._owner_viewport->get_shader(GD_CUBISM_SHADER_MASK);
-    if (shader.is_null())
-        shader = res.get_shader(GD_CUBISM_SHADER_MASK);
-
-    mat->set_shader(shader);
-    mat->set_shader_parameter("channel", Vector4(0.0, 0.0, 0.0, 1.0));
-    mat->set_shader_parameter("tex_main", res.ary_texture[model->GetDrawableTextureIndex(index)]);
-
-    for (Csm::csmInt32 m_index = 0; m_index < model->GetDrawableMaskCounts()[index]; m_index++)
-    {
-        Csm::csmInt32 j = model->GetDrawableMasks()[index][m_index];
-        MeshInstance2D *node = res.request_mesh_instance();
-
-        node->set_mesh(this->make_ArrayMesh(model, j, true, res));
-
-        node->set_material(mat);
-        node->set_z_index(model->GetDrawableRenderOrders()[index]);
-        node->set_visible(true);
-
-        viewport->add_child(node);
-    }
-}
-
 void InternalCubismRenderer2D::update(InternalCubismRendererResource &res)
 {
     const CubismModel *model = this->GetModel();
@@ -317,47 +215,43 @@ void InternalCubismRenderer2D::update(InternalCubismRendererResource &res)
         model,
         res);
 
-    // 描画
     for (Csm::csmInt32 index = 0; index < model->GetDrawableCount(); index++)
     {
-        // Drawableが表示状態でなければ処理をパスする
-        if (model->GetDrawableDynamicFlagIsVisible(index) == false)
-            continue;
         if (model->GetDrawableVertexCount(index) == 0)
             continue;
         if (model->GetDrawableVertexIndexCount(index) == 0)
             continue;
 
-        MeshInstance2D *node = res.request_mesh_instance();
-        Ref<ShaderMaterial> mat = this->make_ShaderMaterial(model, index, res);
-
+        
         CubismIdHandle handle = model->GetDrawableId(index);
         String node_name(handle->GetString().GetRawString());
+        MeshInstance2D *node = Object::cast_to<MeshInstance2D>(res.dict_mesh[node_name]);
+        if (node == nullptr) {
+            continue;
+        }
+        const bool visible = model->GetDrawableDynamicFlagIsVisible(index);
+        node->set_visible(visible);
+        if (!visible) {
+            continue;
+        }
+        Ref<ShaderMaterial> mat = node->get_material();
 
-        if (model->GetDrawableMaskCounts()[index] > 0)
-        {
-            SubViewport *viewport = res.request_viewport();
+        this->update_mesh(model, index, false, res, node->get_mesh());
+        this->update_material(model, index, mat);
+        node->set_z_index(renderOrder[index]);
 
+        if (model->GetDrawableMaskCounts()[index] > 0) {
+            const Array masks = res.dict_mask[node_name];
+            SubViewport *viewport = Object::cast_to<SubViewport>(node->get_meta("viewport"));
             viewport->set_size(res.vct_mask_size);
 
-            viewport->set_disable_3d(SUBVIEWPORT_DISABLE_3D_FLAG);
-            viewport->set_clear_mode(SubViewport::ClearMode::CLEAR_MODE_ALWAYS);
-            // set_update_mode must be specified
-            viewport->set_update_mode(SubViewport::UpdateMode::UPDATE_ALWAYS);
-            viewport->set_disable_input(true);
-            // Memory leak when set_use_own_world_3d is true
-            // https://github.com/godotengine/godot/issues/81476
-            viewport->set_use_own_world_3d(SUBVIEWPORT_USE_OWN_WORLD_3D_FLAG);
-            // Memory leak when set_transparent_background is true(* every time & window minimize)
-            // https://github.com/godotengine/godot/issues/89651
-            viewport->set_transparent_background(true);
-
-            this->update_mask(viewport, index, res);
-
-            // res._parent_node->add_child(viewport);
-            res._parent_node->call_deferred("add_child", viewport);
-
-            mat->set_shader_parameter("tex_mask", viewport->get_texture());
+            for (Csm::csmInt32 m_index = 0; m_index < model->GetDrawableMaskCounts()[index]; m_index++)
+            {
+                MeshInstance2D *node = Object::cast_to<MeshInstance2D>(masks[m_index]);
+                Csm::csmInt32 j = model->GetDrawableMasks()[index][m_index];
+                this->update_mesh(model, j, true, res, node->get_mesh());
+                node->set_z_index(renderOrder[index]);
+            }
 
             mat->set_shader_parameter("auto_scale", res._owner_viewport->auto_scale);
             mat->set_shader_parameter("canvas_size", Vector2(res.vct_canvas_size));
@@ -366,22 +260,10 @@ void InternalCubismRenderer2D::update(InternalCubismRendererResource &res)
             mat->set_shader_parameter("adjust_scale", res.adjust_scale);
             mat->set_shader_parameter("adjust_pos", res.adjust_pos);
         }
-
-        Ref<ArrayMesh> m = this->make_ArrayMesh(model, index, false, res);
-
-        node->set_name(node_name);
-        node->set_mesh(m);
-        res.dict_mesh[node_name] = m;
-        node->set_material(mat);
-        node->set_z_index(renderOrder[index]);
-        node->set_visible(true);
-
-        // res._parent_node->add_child(node);
-        res._parent_node->call_deferred("add_child", node);
     }
 }
 
-void InternalCubismRenderer2D::update(InternalCubismRendererResource &res, const bool update_node, const bool update_mesh)
+void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res)
 {
     const CubismModel *model = this->GetModel();
     const Csm::csmInt32 *renderOrder = model->GetDrawableRenderOrders();
@@ -389,9 +271,6 @@ void InternalCubismRenderer2D::update(InternalCubismRendererResource &res, const
 
     for (Csm::csmInt32 index = 0; index < model->GetDrawableCount(); index++)
     {
-
-        if (model->GetDrawableDynamicFlagIsVisible(index) == false)
-            continue;
         if (model->GetDrawableVertexCount(index) == 0)
             continue;
         if (model->GetDrawableVertexIndexCount(index) == 0)
@@ -400,8 +279,86 @@ void InternalCubismRenderer2D::update(InternalCubismRendererResource &res, const
         CubismIdHandle handle = model->GetDrawableId(index);
         String node_name(handle->GetString().GetRawString());
 
-        res.dict_mesh[node_name] = this->make_ArrayMesh(model, index, false, res);
+        MeshInstance2D* node = res.request_mesh_instance();
+        ShaderMaterial* mat = res.request_shader_material(model, index);
+        node->set_material(mat);        
+        this->update_mesh(model, index, false, res, node->get_mesh());
+        node->set_name(node_name);
+
+        // build mask
+        if (model->GetDrawableMaskCounts()[index] > 0)
+        {
+            TypedArray<MeshInstance2D> masks;
+            
+            SubViewport* viewport = memnew(SubViewport);
+            {
+                viewport->set_size(res.vct_mask_size);
+
+                viewport->set_disable_3d(SUBVIEWPORT_DISABLE_3D_FLAG);
+                viewport->set_clear_mode(SubViewport::ClearMode::CLEAR_MODE_ALWAYS);
+                // set_update_mode must be specified
+                viewport->set_update_mode(SubViewport::UpdateMode::UPDATE_ALWAYS);
+                viewport->set_disable_input(true);
+                // Memory leak when set_use_own_world_3d is true
+                // https://github.com/godotengine/godot/issues/81476
+                viewport->set_use_own_world_3d(SUBVIEWPORT_USE_OWN_WORLD_3D_FLAG);
+                // Memory leak when set_transparent_background is true(* every time & window minimize)
+                // https://github.com/godotengine/godot/issues/89651
+                viewport->set_transparent_background(true);
+
+                for (Csm::csmInt32 m_index = 0; m_index < model->GetDrawableMaskCounts()[index]; m_index++)
+                {
+                    Csm::csmInt32 j = model->GetDrawableMasks()[index][m_index];
+                    CubismIdHandle handle = model->GetDrawableId(j);
+                    String mask_name(handle->GetString().GetRawString());
+
+                    MeshInstance2D *node = res.request_mesh_instance();
+                    ShaderMaterial *mat = res.request_mask_material();
+                    this->update_mesh(model, j, true, res, node->get_mesh());
+
+                    node->set_name(mask_name);
+                    node->set_material(mat);
+                    mat->set_shader_parameter("channel", Vector4(0.0, 0.0, 0.0, 1.0));
+                    mat->set_shader_parameter("tex_main", res.ary_texture[model->GetDrawableTextureIndex(index)]);
+
+                    node->set_z_index(model->GetDrawableRenderOrders()[index]);
+                    node->set_visible(true);
+
+                    masks.append(node);
+
+                    viewport->add_child(node);
+                }
+            }
+
+            res._parent_node->call_deferred("add_child", viewport);
+
+            mat->set_shader_parameter("auto_scale", res._owner_viewport->auto_scale);
+            mat->set_shader_parameter("canvas_size", Vector2(res.vct_canvas_size));
+            mat->set_shader_parameter("mask_size", Vector2(res.vct_mask_size));
+            mat->set_shader_parameter("ratio", res.RATIO);
+            mat->set_shader_parameter("adjust_scale", res.adjust_scale);
+            mat->set_shader_parameter("adjust_pos", res.adjust_pos);
+
+            viewport->set_name(node_name + "__mask");
+            res.dict_mask[node_name] = masks;
+
+            node->set_meta("viewport", viewport);
+
+            // textures from viewports can not be accessed until after the viewport is ready
+            node->connect("ready", callable_mp_static(&InternalCubismRenderer2D::ready_mask).bind(node));
+        }
+
+        res.dict_mesh[node_name] = node;
+        res._parent_node->call_deferred("add_child", node);
+        
+        
     }
+}
+
+void InternalCubismRenderer2D::ready_mask(const MeshInstance2D *node) {
+    SubViewport* viewport = Object::cast_to<SubViewport>(node->get_meta("viewport"));
+    Ref<ShaderMaterial> mat = node->get_material();
+    mat->set_shader_parameter("tex_mask", viewport->get_texture());
 }
 
 void InternalCubismRenderer2D::Initialize(Csm::CubismModel *model, Csm::csmInt32 maskBufferCount)

--- a/src/private/internal_cubism_renderer_2d.hpp
+++ b/src/private/internal_cubism_renderer_2d.hpp
@@ -38,18 +38,20 @@ public:
     virtual ~InternalCubismRenderer2D();
 
 private:
-    Ref<ShaderMaterial> make_ShaderMaterial(const Csm::CubismModel *model, const Csm::csmInt32 index, const InternalCubismRendererResource &res) const;
+    static void ready_mask(const MeshInstance2D *node);
+
+    void update_material(const Csm::CubismModel *model, const Csm::csmInt32 index, const Ref<ShaderMaterial> mat) const;
+    
     void make_ArrayMesh_prepare(
         const Csm::CubismModel *model,
         InternalCubismRendererResource &res);
 
-    Ref<ArrayMesh> make_ArrayMesh(
+    void update_mesh(
         const Csm::CubismModel *model,
         const Csm::csmInt32 index,
         const bool makemask,
-        const InternalCubismRendererResource &res) const;
-
-    void update_mask(SubViewport *viewport, const Csm::csmInt32 index, InternalCubismRendererResource &res);
+        const InternalCubismRendererResource &res,
+        const Ref<ArrayMesh> ary_mesh) const;
 
 public:
     Csm::csmInt32 calc_viewport_count() const;
@@ -59,7 +61,7 @@ public:
     float get_ppunit(const Csm::CubismModel *model) const;
 
     void update(InternalCubismRendererResource &res);
-    void update(InternalCubismRendererResource &res, const bool update_node, const bool update_mesh);
+    void build_model(InternalCubismRendererResource &res);
 
     virtual void Initialize(Csm::CubismModel *model, Csm::csmInt32 maskBufferCount);
     void DoDrawModel();

--- a/src/private/internal_cubism_renderer_resource.cpp
+++ b/src/private/internal_cubism_renderer_resource.cpp
@@ -18,16 +18,12 @@
 // -------------------------------------------------------------------- enum(s)
 // ------------------------------------------------------------------- const(s)
 // ------------------------------------------------------------------ static(s)
-void _recurisive_dispose_node(const Node* parent_node, const bool node_release);
-
 
 // ----------------------------------------------------------- class:forward(s)
 // ------------------------------------------------------------------- class(s)
 InternalCubismRendererResource::InternalCubismRendererResource(GDCubismUserModel *owner_viewport, Node *parent_node)
     : _owner_viewport(owner_viewport)
     , _parent_node(parent_node)
-    , sub_viewport_counter(0)
-    , mesh_instance_counter(0)
     , adjust_pos(0.0, 0.0)
     , adjust_scale(1.0)
 {
@@ -61,73 +57,96 @@ InternalCubismRendererResource::~InternalCubismRendererResource() {
 
 
 void InternalCubismRendererResource::clear() {
-    this->dispose_node(true);
     this->ary_texture.clear();
-    this->ary_sub_viewport.clear();
-    this->ary_mesh_instance.clear();
+    this->dict_mesh.clear();
+    this->dict_mask.clear();
 }
-
-
-SubViewport* InternalCubismRendererResource::request_viewport() {
-    const Csm::csmInt32 counter = this->sub_viewport_counter++;
-
-    if(counter < this->ary_sub_viewport.size()) {
-        return Object::cast_to<SubViewport>(this->ary_sub_viewport[counter]);
-    } else {
-        SubViewport* viewport = memnew(SubViewport);
-        this->ary_sub_viewport.append(viewport);
-        return viewport;
-    }
-};
-
 
 MeshInstance2D* InternalCubismRendererResource::request_mesh_instance() {
-    const Csm::csmInt32 counter = this->mesh_instance_counter++;
-
-    if(counter < this->ary_mesh_instance.size()) {
-        return Object::cast_to<MeshInstance2D>(this->ary_mesh_instance[counter]);
-    } else {
-        MeshInstance2D* node = memnew(MeshInstance2D);
-        this->ary_mesh_instance.append(node);
-        return node;
-    }
+    ArrayMesh* mesh = memnew(ArrayMesh);
+    MeshInstance2D* node = memnew(MeshInstance2D);
+    node->set_mesh(mesh);
+    return node;
 }
 
-
-void InternalCubismRendererResource::pro_proc(const Csm::csmInt32 viewport_count, const Csm::csmInt32 mesh_instance_count) {
-    this->dispose_node(false);
-    this->dict_mesh.clear();
-    this->sub_viewport_counter = 0;
-    this->mesh_instance_counter = 0;
-}
-
-
-void InternalCubismRendererResource::epi_proc() {}
-
-
-void InternalCubismRendererResource::dispose_node(const bool node_release) {
-    _recurisive_dispose_node(this->_parent_node, node_release);
-}
-
-
-// ------------------------------------------------------------------ method(s)
-void _recurisive_dispose_node(const Node* parent_node, const bool node_release) {
-
-    TypedArray<Node> ary_node = parent_node->get_children();
-
-    for(Csm::csmInt32 i = 0; i < ary_node.size(); i++) {
-
-        if(Object::cast_to<GDCubismEffect>(ary_node[i]) != nullptr) continue;
-
-        MeshInstance2D *m_node = Object::cast_to<MeshInstance2D>(ary_node[i]);
-        if(m_node != nullptr) m_node->set_material(nullptr);
-
-        Node* node = Object::cast_to<Node>(ary_node[i]);
-        if(node != nullptr) {
-            _recurisive_dispose_node(node, node_release);
-            if(node->get_parent() != nullptr) node->get_parent()->remove_child(node);
-            if(node_release == true) node->queue_free();
+ShaderMaterial* InternalCubismRendererResource::request_shader_material(const Csm::CubismModel *model, const Csm::csmInt32 index) {
+    ShaderMaterial* mat = memnew(ShaderMaterial);
+    
+    GDCubismShader e = GD_CUBISM_SHADER_NORM_MIX;
+    if (model->GetDrawableMaskCounts()[index] == 0)
+    {
+        switch (model->GetDrawableBlendMode(index))
+        {
+        case CubismRenderer::CubismBlendMode_Additive:
+            e = GD_CUBISM_SHADER_NORM_ADD;
+            break;
+        case CubismRenderer::CubismBlendMode_Normal:
+            e = GD_CUBISM_SHADER_NORM_MIX;
+            break;
+        case CubismRenderer::CubismBlendMode_Multiplicative:
+            e = GD_CUBISM_SHADER_NORM_MUL;
+            break;
+        default:
+            e = GD_CUBISM_SHADER_NORM_MIX;
+            break;
         }
     }
+    else if (model->GetDrawableInvertedMask(index) == false)
+    {
+        switch (model->GetDrawableBlendMode(index))
+        {
+        case CubismRenderer::CubismBlendMode_Additive:
+            e = GD_CUBISM_SHADER_MASK_ADD;
+            break;
+        case CubismRenderer::CubismBlendMode_Normal:
+            e = GD_CUBISM_SHADER_MASK_MIX;
+            break;
+        case CubismRenderer::CubismBlendMode_Multiplicative:
+            e = GD_CUBISM_SHADER_MASK_MUL;
+            break;
+        default:
+            e = GD_CUBISM_SHADER_MASK_MIX;
+            break;
+        }
+    }
+    else
+    {
+        switch (model->GetDrawableBlendMode(index))
+        {
+        case CubismRenderer::CubismBlendMode_Additive:
+            e = GD_CUBISM_SHADER_MASK_ADD_INV;
+            break;
+        case CubismRenderer::CubismBlendMode_Normal:
+            e = GD_CUBISM_SHADER_MASK_MIX_INV;
+            break;
+        case CubismRenderer::CubismBlendMode_Multiplicative:
+            e = GD_CUBISM_SHADER_MASK_MUL_INV;
+            break;
+        default:
+            e = GD_CUBISM_SHADER_MASK_MIX_INV;
+            break;
+        }
+    }
+
+    Ref<Shader> shader = this->_owner_viewport->get_shader(e);
+    if (shader.is_null())
+        shader = this->get_shader(e);
+
+    mat->set_shader(shader);
+    mat->set_shader_parameter("channel", Vector4(0.0, 0.0, 0.0, 1.0));
+    mat->set_shader_parameter("tex_main", this->ary_texture[model->GetDrawableTextureIndex(index)]);
+
+    return mat;
 }
 
+ShaderMaterial* InternalCubismRendererResource::request_mask_material() {
+    ShaderMaterial* mat = memnew(ShaderMaterial);
+
+    Ref<Shader> shader = this->_owner_viewport->get_shader(GD_CUBISM_SHADER_MASK);
+    if (shader.is_null())
+        shader = this->get_shader(GD_CUBISM_SHADER_MASK);
+
+    mat->set_shader(shader);
+    
+    return mat;
+}

--- a/src/private/internal_cubism_renderer_resource.hpp
+++ b/src/private/internal_cubism_renderer_resource.hpp
@@ -20,6 +20,7 @@
 
 // ------------------------------------------------------------------ define(s)
 // --------------------------------------------------------------- namespace(s)
+using namespace Live2D::Cubism::Framework::Rendering;
 using namespace godot;
 
 
@@ -40,27 +41,24 @@ public:
 
     SubViewport* request_viewport();
     MeshInstance2D* request_mesh_instance();
+    ShaderMaterial* request_shader_material(const Csm::CubismModel *model, const Csm::csmInt32 index);
+    ShaderMaterial* request_mask_material();
 
     void pro_proc(const Csm::csmInt32 viewport_count, const Csm::csmInt32 mesh_instance_count);
     void epi_proc();
-
-    void dispose_node(const bool node_release);
 
     // Shader
     Ref<Shader> get_shader(const GDCubismShader e) const { return this->ary_shader[e]; }
 
 public:
-    const GDCubismUserModel *_owner_viewport;
+    GDCubismUserModel *_owner_viewport;
     Node *_parent_node;
 
     Array ary_texture;
     Array ary_shader;
     Dictionary dict_mesh;
-    Csm::csmInt32 sub_viewport_counter;
-    TypedArray<SubViewport> ary_sub_viewport;
-    Csm::csmInt32 mesh_instance_counter;
-    TypedArray<MeshInstance2D> ary_mesh_instance;
-
+    Dictionary dict_mask;
+    
     // Adjust Parameters
     Vector2 adjust_pos;
     float adjust_scale;

--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -138,16 +138,9 @@ bool InternalCubismUserModel::model_load(const String &model_pathname) {
         this->_renderer_resource.adjust_scale = this->_owner_viewport->adjust_scale;
         this->_renderer_resource.adjust_pos = this->_owner_viewport->adjust_pos;
 
-        this->_renderer_resource.pro_proc(
-            renderer->calc_viewport_count(),
-            renderer->calc_mesh_instance_count()
-        );
-
         renderer->IsPremultipliedAlpha(false);
         renderer->DrawModel();
-        renderer->update(this->_renderer_resource, false, true);
-
-        this->_renderer_resource.epi_proc();
+        renderer->build_model(this->_renderer_resource);
     }
     // ------------------------------------------------------------------------
 
@@ -238,16 +231,9 @@ void InternalCubismUserModel::update_node() {
     this->_renderer_resource.adjust_scale = this->_owner_viewport->adjust_scale;
     this->_renderer_resource.adjust_pos = this->_owner_viewport->adjust_pos;
 
-    this->_renderer_resource.pro_proc(
-        renderer->calc_viewport_count(),
-        renderer->calc_mesh_instance_count()
-    );
-
     renderer->IsPremultipliedAlpha(false);
     renderer->DrawModel();
     renderer->update(this->_renderer_resource);
-
-    this->_renderer_resource.epi_proc();
 }
 
 


### PR DESCRIPTION
While working on a [vtubing app](https://github.com/erodozer/open-vt) with focus on Live2D models, I've made some adjustments to gd_cubism to improve usability and stability.

- all parts are now generated on model load and mutated in-place during update cycles
- to avoid issues with changing the model at runtime, GDCubismUserModel is now treated as immutable after initialization.  If you wish to change the model at runtime, instead just initialize a new instance with the different model
- changes the mix shader to respect the modulate color on canvas items, allowing for individual parts to be tinted