### PR TITLE
Avoid frequent allocations

### DIFF
--- a/demo/addons/gd_cubism/cs/gd_cubism_user_model_cs.cs
+++ b/demo/addons/gd_cubism/cs/gd_cubism_user_model_cs.cs
@@ -126,7 +126,7 @@ public partial class GDCubismUserModelCS : GodotObject
     ///     You can load a Live2D model by specifying a file with the *.model3.json extension.
     ///     The file is loaded immediately upon specification.
     ///     <br />
-    ///     The <c>clear</c> function is called internally, so if you want to switch the Live2D model, you can do so simply by specifying a new file.
+    ///     if you want to switch the Live2D model, you can do so simply by specifying a new file.
     /// </value>
     public String Assets
     {
@@ -281,14 +281,6 @@ public partial class GDCubismUserModelCS : GodotObject
     public void Advance(float delta)
     {
         this.InternalObject.Call("advance", delta);
-    }
-
-    /// <summary>
-    ///     Disposes of the currently held Live2D model.
-    /// </summary>
-    public void Clear()
-    {
-        this.InternalObject.Call("clear");
     }
 
     /// <summary>

--- a/doc_classes/GDCubismUserModel.xml
+++ b/doc_classes/GDCubismUserModel.xml
@@ -16,12 +16,6 @@
 				Please specify a value of 0.0 or more for delta.
 			</description>
 		</method>
-		<method name="clear">
-			<return type="void" />
-			<description>
-				Destroys the currently held Live2D model.
-			</description>
-		</method>
 		<method name="csm_get_latest_moc_version">
 			<return type="int" enum="GDCubismUserModel.moc3FileFormatVersion" />
 			<description>
@@ -181,7 +175,7 @@
 		</member>
 		<member name="assets" type="String" setter="set_assets" getter="get_assets" default="&quot;&quot;">
 			By specifying a file with the [code]*.model3.json[/code] extension, you can load the Live2D model. As soon as you specify a file, it will be loaded immediately.
-			Since the [method GDCubismUserModel.clear] function is called internally, if you want to switch the Live2D model, you can do so by simply specifying a new file.
+			if you want to switch the Live2D model, you can do so by simply specifying a new file.
 		</member>
 		<member name="auto_scale" type="bool" setter="set_auto_scale" getter="get_auto_scale" default="true">
 			[GDCubismUserModel] tries to render the Live2D model to fit within the [SubViewport] size specified for itself. Therefore, there may be results that the creator of the Live2D model did not intend.

--- a/docs-src/modules/ROOT/pages/en/api/gd_cubism_user_model.adoc
+++ b/docs-src/modules/ROOT/pages/en/api/gd_cubism_user_model.adoc
@@ -171,7 +171,7 @@ By adjusting this parameter, you can freely change the rendering size of the Liv
 [[id-property-assets]]
 String assets [default: ""]::
 By specifying a file with the *.model3.json extension, you can load the Live2D model. As soon as you specify a file, it will be loaded immediately. +
-Since the _clear_ function is called internally, if you want to switch the Live2D model, you can do so by simply specifying a new file.
+if you want to switch the Live2D model, you can do so by simply specifying a new file.
 
 
 [[id-property-auto_scale]]
@@ -340,7 +340,8 @@ Please specify a value of 0.0 or more for delta.
 
 [[id-method-clear]]
 void clear()::
-Destroys the currently held Live2D model.
+This function was removed to improve operational consistency. +
+For similar operations, please set the _assets_ property to "".
 
 
 [[id-method-csm_get_latest_moc_version]]

--- a/docs-src/modules/ROOT/pages/ja/api/gd_cubism_user_model.adoc
+++ b/docs-src/modules/ROOT/pages/ja/api/gd_cubism_user_model.adoc
@@ -167,7 +167,7 @@ GDCubismは自身が持つSubViewport内にLive2Dモデルの描画を行いま�
 String assets [default: ""]::
 *.model3.json 拡張子のファイルを指定することでLive2Dモデルを読み込みます。
 ファイルを指定すると即座にファイルが読み込まれます。 +
-内部で _clear_ 関数を呼び出しているため、Live2Dモデルを切り替えたい場合は新しいファイルを指定するだけで切り替える事が出来ます。
+Live2Dモデルを切り替えたい場合は新しいファイルを指定するだけで切り替える事が出来ます。
 
 
 [[id-property-auto_scale]]
@@ -336,7 +336,8 @@ deltaには 0.0 以上の値を指定してください。
 
 [[id-method-clear]]
 void clear()::
-現在保持しているLive2Dモデルを破棄します。
+この関数は操作の一貫性向上を目的に削除されました。 +
+同様の操作を行うには _assets_ プロパティに "" をセットしてください。
 
 
 [[id-method-csm_get_latest_moc_version]]

--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -226,8 +226,12 @@ GDCubismUserModel::moc3FileFormatVersion GDCubismUserModel::csm_get_moc_version(
 
 
 void GDCubismUserModel::set_assets(const String assets) {
-    ERR_FAIL_COND_MSG(!assets.ends_with(".model3.json"), "Must point to Live2D model3.json file");
-    ERR_FAIL_COND_MSG(!FileAccess::file_exists(assets), "Could not find model path");
+    if (!assets.ends_with(".model3.json")) {
+        WARN_PRINT("GDCubismUserModel must point to a Live2D model3.json file");
+    }
+    if (!FileAccess::file_exists(assets)) {
+        WARN_PRINT("Live2D file does not exist, will be unable to initialize model.");
+    }
     this->assets = assets;
     this->load_model(assets);
 }
@@ -785,6 +789,10 @@ void GDCubismUserModel::clear() {
 void GDCubismUserModel::load_model(const String assets) {
     this->clear();
 
+    if (assets.is_empty()) {
+        return;
+    }
+
     Ref<FileAccess> f = FileAccess::open(assets, FileAccess::READ);
     ERR_FAIL_COND_MSG(f.is_null(), "Could not open model path.  Make sure to point to the model3.json");
 
@@ -799,11 +807,6 @@ void GDCubismUserModel::load_model(const String assets) {
     }
 
     Csm::CubismModel *model = this->internal_model->GetModel();
-
-    this->set_size(Vector2i(
-        model->GetCanvasWidthPixel(),
-        model->GetCanvasHeightPixel()
-    ));
 
     {
         this->ary_parameter.clear();

--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -768,15 +768,6 @@ void GDCubismUserModel::_get_property_list(List<godot::PropertyInfo> *p_list) {
 }
 
 void GDCubismUserModel::clear() {
-    while (this->get_child_count(true) > 0) {
-        auto const& c = this->get_child(0, true);
-        c->queue_free();
-        this->remove_child(c);
-    }
-
-    if(!this->is_initialized()) {
-        return;
-    }
     if(this->internal_model == nullptr) {
         return;
     }

--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -50,10 +50,7 @@ GDCubismUserModel::GDCubismUserModel()
 }
 
 
-GDCubismUserModel::~GDCubismUserModel() {
-    this->ary_shader.clear();
-    this->clear();
-}
+GDCubismUserModel::~GDCubismUserModel() {}
 
 
 void GDCubismUserModel::_bind_methods() {
@@ -198,6 +195,14 @@ void GDCubismUserModel::_bind_methods() {
     BIND_ENUM_CONSTANT(PHYSICS);
     BIND_ENUM_CONSTANT(IDLE);
     BIND_ENUM_CONSTANT(MANUAL);
+}
+
+
+void GDCubismUserModel::_notification(int p_what) {
+    if (p_what == NOTIFICATION_PREDELETE) {
+        this->clear();
+        this->ary_shader.clear();
+    }
 }
 
 

--- a/src/gd_cubism_user_model.hpp
+++ b/src/gd_cubism_user_model.hpp
@@ -133,6 +133,7 @@ public:
 
 protected:
     static void _bind_methods();
+    void _notification(int p_what);
 
 private:
     void load_model(const String asset_path);

--- a/src/gd_cubism_user_model.hpp
+++ b/src/gd_cubism_user_model.hpp
@@ -134,6 +134,10 @@ public:
 protected:
     static void _bind_methods();
 
+private:
+    void load_model(const String asset_path);
+    void clear();
+
 public:
     Dictionary csm_get_version();
     moc3FileFormatVersion csm_get_latest_moc_version();
@@ -150,7 +154,6 @@ public:
     Dictionary get_canvas_info() const;
 
     bool is_initialized() const;
-    void clear();
 
     void set_parameter_mode(const ParameterMode value);
     GDCubismUserModel::ParameterMode get_parameter_mode() const;

--- a/src/private/internal_cubism_renderer_2d.cpp
+++ b/src/private/internal_cubism_renderer_2d.cpp
@@ -269,6 +269,7 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res, 
         if (model->GetDrawableMaskCounts()[index] > 0)
         {
             TypedArray<MeshInstance2D> masks;
+            masks.resize(model->GetDrawableMaskCounts()[index]);
             
             SubViewport* viewport = memnew(SubViewport);
             {
@@ -285,8 +286,6 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res, 
                 // Memory leak when set_transparent_background is true(* every time & window minimize)
                 // https://github.com/godotengine/godot/issues/89651
                 viewport->set_transparent_background(true);
-
-                masks.resize(model->GetDrawableMaskCounts()[index]);
 
                 for (Csm::csmInt32 m_index = 0; m_index < model->GetDrawableMaskCounts()[index]; m_index++)
                 {

--- a/src/private/internal_cubism_renderer_2d.cpp
+++ b/src/private/internal_cubism_renderer_2d.cpp
@@ -302,10 +302,12 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res, 
                     masks.append(node);
 
                     viewport->add_child(node);
+                    res.managed_nodes.append(node);
                 }
             }
 
             target_node->add_child(viewport);
+            res.managed_nodes.append(viewport);
 
             mat->set_shader_parameter("tex_mask", viewport->get_texture());
             mat->set_shader_parameter("auto_scale", res._owner_viewport->auto_scale);
@@ -323,6 +325,7 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res, 
 
         res.dict_mesh[node_name] = node;
         target_node->add_child(node);
+        res.managed_nodes.append(node);
     }
 }
 

--- a/src/private/internal_cubism_renderer_2d.hpp
+++ b/src/private/internal_cubism_renderer_2d.hpp
@@ -38,28 +38,28 @@ public:
     virtual ~InternalCubismRenderer2D();
 
 private:
-    Ref<ShaderMaterial> make_ShaderMaterial(const Csm::CubismModel *model, const Csm::csmInt32 index, const InternalCubismRendererResource &res) const;
+    static void ready_mask(const MeshInstance2D *node);
+
+    void update_material(const Csm::CubismModel *model, const Csm::csmInt32 index, const Ref<ShaderMaterial> mat) const;
+    
     void make_ArrayMesh_prepare(
         const Csm::CubismModel *model,
         InternalCubismRendererResource &res);
 
-    Ref<ArrayMesh> make_ArrayMesh(
+    void update_mesh(
         const Csm::CubismModel *model,
         const Csm::csmInt32 index,
         const bool makemask,
-        const InternalCubismRendererResource &res) const;
-
-    void update_mask(SubViewport *viewport, const Csm::csmInt32 index, InternalCubismRendererResource &res);
+        const InternalCubismRendererResource &res,
+        const Ref<ArrayMesh> ary_mesh) const;
 
 public:
-    Csm::csmInt32 calc_viewport_count() const;
-    Csm::csmInt32 calc_mesh_instance_count() const;
     Vector2 get_size(const Csm::CubismModel *model) const;
     Vector2 get_origin(const Csm::CubismModel *model) const;
     float get_ppunit(const Csm::CubismModel *model) const;
 
     void update(InternalCubismRendererResource &res);
-    void update(InternalCubismRendererResource &res, const bool update_node, const bool update_mesh);
+    void build_model(InternalCubismRendererResource &res, Node *target_node);
 
     virtual void Initialize(Csm::CubismModel *model, Csm::csmInt32 maskBufferCount);
     void DoDrawModel();

--- a/src/private/internal_cubism_renderer_resource.cpp
+++ b/src/private/internal_cubism_renderer_resource.cpp
@@ -11,7 +11,7 @@
 
 #include <private/internal_cubism_renderer_resource.hpp>
 #include <gd_cubism_user_model.hpp>
-
+#include <godot_cpp/variant/utility_functions.hpp>
 
 // ------------------------------------------------------------------ define(s)
 // --------------------------------------------------------------- namespace(s)
@@ -56,6 +56,7 @@ InternalCubismRendererResource::~InternalCubismRendererResource() {
 
 void InternalCubismRendererResource::clear() {
     for (int i = 0; i < this->managed_nodes.size(); i++) {
+        if (!UtilityFunctions::is_instance_id_valid(this->managed_nodes[i])) continue;
         Node *c = Object::cast_to<Node>(this->managed_nodes[i]);
         c->get_parent()->remove_child(c);
         c->queue_free();

--- a/src/private/internal_cubism_renderer_resource.cpp
+++ b/src/private/internal_cubism_renderer_resource.cpp
@@ -18,16 +18,11 @@
 // -------------------------------------------------------------------- enum(s)
 // ------------------------------------------------------------------- const(s)
 // ------------------------------------------------------------------ static(s)
-void _recurisive_dispose_node(const Node* parent_node, const bool node_release);
-
 
 // ----------------------------------------------------------- class:forward(s)
 // ------------------------------------------------------------------- class(s)
-InternalCubismRendererResource::InternalCubismRendererResource(GDCubismUserModel *owner_viewport, Node *parent_node)
+InternalCubismRendererResource::InternalCubismRendererResource(GDCubismUserModel *owner_viewport)
     : _owner_viewport(owner_viewport)
-    , _parent_node(parent_node)
-    , sub_viewport_counter(0)
-    , mesh_instance_counter(0)
     , adjust_pos(0.0, 0.0)
     , adjust_scale(1.0)
 {
@@ -56,78 +51,100 @@ InternalCubismRendererResource::~InternalCubismRendererResource() {
     this->clear();
     this->ary_shader.clear();
     this->_owner_viewport = nullptr;
-    this->_parent_node = nullptr;
 }
 
 
 void InternalCubismRendererResource::clear() {
-    this->dispose_node(true);
     this->ary_texture.clear();
-    this->ary_sub_viewport.clear();
-    this->ary_mesh_instance.clear();
+    this->dict_mesh.clear();
+    this->dict_mask.clear();
 }
-
-
-SubViewport* InternalCubismRendererResource::request_viewport() {
-    const Csm::csmInt32 counter = this->sub_viewport_counter++;
-
-    if(counter < this->ary_sub_viewport.size()) {
-        return Object::cast_to<SubViewport>(this->ary_sub_viewport[counter]);
-    } else {
-        SubViewport* viewport = memnew(SubViewport);
-        this->ary_sub_viewport.append(viewport);
-        return viewport;
-    }
-};
-
 
 MeshInstance2D* InternalCubismRendererResource::request_mesh_instance() {
-    const Csm::csmInt32 counter = this->mesh_instance_counter++;
-
-    if(counter < this->ary_mesh_instance.size()) {
-        return Object::cast_to<MeshInstance2D>(this->ary_mesh_instance[counter]);
-    } else {
-        MeshInstance2D* node = memnew(MeshInstance2D);
-        this->ary_mesh_instance.append(node);
-        return node;
-    }
+    ArrayMesh* mesh = memnew(ArrayMesh);
+    MeshInstance2D* node = memnew(MeshInstance2D);
+    node->set_mesh(mesh);
+    return node;
 }
 
-
-void InternalCubismRendererResource::pro_proc(const Csm::csmInt32 viewport_count, const Csm::csmInt32 mesh_instance_count) {
-    this->dispose_node(false);
-    this->dict_mesh.clear();
-    this->sub_viewport_counter = 0;
-    this->mesh_instance_counter = 0;
-}
-
-
-void InternalCubismRendererResource::epi_proc() {}
-
-
-void InternalCubismRendererResource::dispose_node(const bool node_release) {
-    _recurisive_dispose_node(this->_parent_node, node_release);
-}
-
-
-// ------------------------------------------------------------------ method(s)
-void _recurisive_dispose_node(const Node* parent_node, const bool node_release) {
-
-    TypedArray<Node> ary_node = parent_node->get_children();
-
-    for(Csm::csmInt32 i = 0; i < ary_node.size(); i++) {
-
-        if(Object::cast_to<GDCubismEffect>(ary_node[i]) != nullptr) continue;
-
-        MeshInstance2D *m_node = Object::cast_to<MeshInstance2D>(ary_node[i]);
-        if(m_node != nullptr) m_node->set_material(nullptr);
-
-        Node* node = Object::cast_to<Node>(ary_node[i]);
-        if(node != nullptr) {
-            _recurisive_dispose_node(node, node_release);
-            if(node->get_parent() != nullptr) node->get_parent()->remove_child(node);
-            if(node_release == true) node->queue_free();
+ShaderMaterial* InternalCubismRendererResource::request_shader_material(const Csm::CubismModel *model, const Csm::csmInt32 index) {
+    ShaderMaterial* mat = memnew(ShaderMaterial);
+    
+    GDCubismShader e = GD_CUBISM_SHADER_NORM_MIX;
+    if (model->GetDrawableMaskCounts()[index] == 0)
+    {
+        switch (model->GetDrawableBlendMode(index))
+        {
+        case CubismRenderer::CubismBlendMode_Additive:
+            e = GD_CUBISM_SHADER_NORM_ADD;
+            break;
+        case CubismRenderer::CubismBlendMode_Normal:
+            e = GD_CUBISM_SHADER_NORM_MIX;
+            break;
+        case CubismRenderer::CubismBlendMode_Multiplicative:
+            e = GD_CUBISM_SHADER_NORM_MUL;
+            break;
+        default:
+            e = GD_CUBISM_SHADER_NORM_MIX;
+            break;
         }
     }
+    else if (model->GetDrawableInvertedMask(index) == false)
+    {
+        switch (model->GetDrawableBlendMode(index))
+        {
+        case CubismRenderer::CubismBlendMode_Additive:
+            e = GD_CUBISM_SHADER_MASK_ADD;
+            break;
+        case CubismRenderer::CubismBlendMode_Normal:
+            e = GD_CUBISM_SHADER_MASK_MIX;
+            break;
+        case CubismRenderer::CubismBlendMode_Multiplicative:
+            e = GD_CUBISM_SHADER_MASK_MUL;
+            break;
+        default:
+            e = GD_CUBISM_SHADER_MASK_MIX;
+            break;
+        }
+    }
+    else
+    {
+        switch (model->GetDrawableBlendMode(index))
+        {
+        case CubismRenderer::CubismBlendMode_Additive:
+            e = GD_CUBISM_SHADER_MASK_ADD_INV;
+            break;
+        case CubismRenderer::CubismBlendMode_Normal:
+            e = GD_CUBISM_SHADER_MASK_MIX_INV;
+            break;
+        case CubismRenderer::CubismBlendMode_Multiplicative:
+            e = GD_CUBISM_SHADER_MASK_MUL_INV;
+            break;
+        default:
+            e = GD_CUBISM_SHADER_MASK_MIX_INV;
+            break;
+        }
+    }
+
+    Ref<Shader> shader = this->_owner_viewport->get_shader(e);
+    if (shader.is_null())
+        shader = this->get_shader(e);
+
+    mat->set_shader(shader);
+    mat->set_shader_parameter("channel", Vector4(0.0, 0.0, 0.0, 1.0));
+    mat->set_shader_parameter("tex_main", this->ary_texture[model->GetDrawableTextureIndex(index)]);
+
+    return mat;
 }
 
+ShaderMaterial* InternalCubismRendererResource::request_mask_material() {
+    ShaderMaterial* mat = memnew(ShaderMaterial);
+
+    Ref<Shader> shader = this->_owner_viewport->get_shader(GD_CUBISM_SHADER_MASK);
+    if (shader.is_null())
+        shader = this->get_shader(GD_CUBISM_SHADER_MASK);
+
+    mat->set_shader(shader);
+    
+    return mat;
+}

--- a/src/private/internal_cubism_renderer_resource.cpp
+++ b/src/private/internal_cubism_renderer_resource.cpp
@@ -55,6 +55,14 @@ InternalCubismRendererResource::~InternalCubismRendererResource() {
 
 
 void InternalCubismRendererResource::clear() {
+    for (int i = 0; i < this->managed_nodes.size(); i++) {
+        Node *c = Object::cast_to<Node>(this->managed_nodes[i]);
+        c->get_parent()->remove_child(c);
+        c->queue_free();
+    }
+
+    this->managed_nodes.clear();
+
     this->ary_texture.clear();
     this->dict_mesh.clear();
     this->dict_mask.clear();

--- a/src/private/internal_cubism_renderer_resource.cpp
+++ b/src/private/internal_cubism_renderer_resource.cpp
@@ -11,7 +11,7 @@
 
 #include <private/internal_cubism_renderer_resource.hpp>
 #include <gd_cubism_user_model.hpp>
-#include <godot_cpp/variant/utility_functions.hpp>
+
 
 // ------------------------------------------------------------------ define(s)
 // --------------------------------------------------------------- namespace(s)
@@ -56,7 +56,6 @@ InternalCubismRendererResource::~InternalCubismRendererResource() {
 
 void InternalCubismRendererResource::clear() {
     for (int i = 0; i < this->managed_nodes.size(); i++) {
-        if (!UtilityFunctions::is_instance_valid(this->managed_nodes[i])) continue;
         Node *c = Object::cast_to<Node>(this->managed_nodes[i]);
         c->get_parent()->remove_child(c);
         c->queue_free();

--- a/src/private/internal_cubism_renderer_resource.cpp
+++ b/src/private/internal_cubism_renderer_resource.cpp
@@ -56,7 +56,7 @@ InternalCubismRendererResource::~InternalCubismRendererResource() {
 
 void InternalCubismRendererResource::clear() {
     for (int i = 0; i < this->managed_nodes.size(); i++) {
-        if (!UtilityFunctions::is_instance_id_valid(this->managed_nodes[i])) continue;
+        if (!UtilityFunctions::is_instance_valid(this->managed_nodes[i])) continue;
         Node *c = Object::cast_to<Node>(this->managed_nodes[i]);
         c->get_parent()->remove_child(c);
         c->queue_free();

--- a/src/private/internal_cubism_renderer_resource.hpp
+++ b/src/private/internal_cubism_renderer_resource.hpp
@@ -20,6 +20,7 @@
 
 // ------------------------------------------------------------------ define(s)
 // --------------------------------------------------------------- namespace(s)
+using namespace Live2D::Cubism::Framework::Rendering;
 using namespace godot;
 
 
@@ -33,34 +34,27 @@ class GDCubismUserModel;
 // ------------------------------------------------------------------- class(s)
 class InternalCubismRendererResource {
 public:
-    InternalCubismRendererResource(GDCubismUserModel *owner_viewport, Node *parent_node);
+    InternalCubismRendererResource(GDCubismUserModel *owner_viewport);
     ~InternalCubismRendererResource();
 
     void clear();
 
     SubViewport* request_viewport();
     MeshInstance2D* request_mesh_instance();
-
-    void pro_proc(const Csm::csmInt32 viewport_count, const Csm::csmInt32 mesh_instance_count);
-    void epi_proc();
-
-    void dispose_node(const bool node_release);
+    ShaderMaterial* request_shader_material(const Csm::CubismModel *model, const Csm::csmInt32 index);
+    ShaderMaterial* request_mask_material();
 
     // Shader
     Ref<Shader> get_shader(const GDCubismShader e) const { return this->ary_shader[e]; }
 
 public:
-    const GDCubismUserModel *_owner_viewport;
-    Node *_parent_node;
+    GDCubismUserModel *_owner_viewport;
 
     Array ary_texture;
     Array ary_shader;
     Dictionary dict_mesh;
-    Csm::csmInt32 sub_viewport_counter;
-    TypedArray<SubViewport> ary_sub_viewport;
-    Csm::csmInt32 mesh_instance_counter;
-    TypedArray<MeshInstance2D> ary_mesh_instance;
-
+    Dictionary dict_mask;
+    
     // Adjust Parameters
     Vector2 adjust_pos;
     float adjust_scale;

--- a/src/private/internal_cubism_renderer_resource.hpp
+++ b/src/private/internal_cubism_renderer_resource.hpp
@@ -50,6 +50,7 @@ public:
 public:
     GDCubismUserModel *_owner_viewport;
 
+    TypedArray<Node> managed_nodes;
     Array ary_texture;
     Array ary_shader;
     Dictionary dict_mesh;

--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -24,12 +24,11 @@ using namespace Live2D::Cubism::Framework;
 // ------------------------------------------------------------------ static(s)
 // ----------------------------------------------------------- class:forward(s)
 // ------------------------------------------------------------------- class(s)
-InternalCubismUserModel::InternalCubismUserModel(GDCubismUserModel *owner_viewport, Node *parent_node)
+InternalCubismUserModel::InternalCubismUserModel(GDCubismUserModel *owner_viewport)
     : CubismUserModel()
     , _moc3_file_format_version(GDCubismUserModel::moc3FileFormatVersion::CSM_MOC_VERSION_UNKNOWN)
-    , _renderer_resource(owner_viewport, parent_node)
+    , _renderer_resource(owner_viewport)
     , _owner_viewport(owner_viewport)
-    , _parent_node(parent_node)
     , _model_pathname("")
     , _model_setting(nullptr) {
 
@@ -42,7 +41,9 @@ InternalCubismUserModel::~InternalCubismUserModel() {
 }
 
 
-bool InternalCubismUserModel::model_load(const String &model_pathname) {
+bool InternalCubismUserModel::model_load(
+    const String &model_pathname
+) {
 
     this->_model_pathname = model_pathname;
     this->_updating = true;
@@ -108,7 +109,7 @@ bool InternalCubismUserModel::model_load(const String &model_pathname) {
     this->_model->SaveParameters();
 
     // Motion
-    if(this->_owner_viewport->enable_load_motions== true) {
+    if(this->_owner_viewport->enable_load_motions == true) {
         this->motion_load();
     }
 
@@ -138,16 +139,9 @@ bool InternalCubismUserModel::model_load(const String &model_pathname) {
         this->_renderer_resource.adjust_scale = this->_owner_viewport->adjust_scale;
         this->_renderer_resource.adjust_pos = this->_owner_viewport->adjust_pos;
 
-        this->_renderer_resource.pro_proc(
-            renderer->calc_viewport_count(),
-            renderer->calc_mesh_instance_count()
-        );
-
         renderer->IsPremultipliedAlpha(false);
         renderer->DrawModel();
-        renderer->update(this->_renderer_resource, false, true);
-
-        this->_renderer_resource.epi_proc();
+        renderer->build_model(this->_renderer_resource, this->_owner_viewport);
     }
     // ------------------------------------------------------------------------
 
@@ -238,16 +232,9 @@ void InternalCubismUserModel::update_node() {
     this->_renderer_resource.adjust_scale = this->_owner_viewport->adjust_scale;
     this->_renderer_resource.adjust_pos = this->_owner_viewport->adjust_pos;
 
-    this->_renderer_resource.pro_proc(
-        renderer->calc_viewport_count(),
-        renderer->calc_mesh_instance_count()
-    );
-
     renderer->IsPremultipliedAlpha(false);
     renderer->DrawModel();
     renderer->update(this->_renderer_resource);
-
-    this->_renderer_resource.epi_proc();
 }
 
 

--- a/src/private/internal_cubism_user_model.hpp
+++ b/src/private/internal_cubism_user_model.hpp
@@ -44,12 +44,11 @@ class InternalCubismUserModel : public Csm::CubismUserModel {
     };
 
 public:
-    InternalCubismUserModel(GDCubismUserModel *owner_viewport, Node *parent_node);
+    InternalCubismUserModel(GDCubismUserModel *owner_viewport);
     virtual ~InternalCubismUserModel();
 
 public:
     GDCubismUserModel *_owner_viewport = nullptr;
-    Node* _parent_node = nullptr;
 
 private:
     InternalCubismRendererResource _renderer_resource;


### PR DESCRIPTION
Decreases the number of objects being allocated by building the mesh upfront and performing in-place updates.

This is a reduction of #121 to address specifically issue #122