### PR TITLE
Load Motions as Animation Resources

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -197,6 +197,8 @@ print("")
 
 sources = glob("src/*.cpp")
 sources += glob("src/private/*.cpp")
+sources += glob("src/loaders/*.cpp")
+sources += glob("src/importers/*.cpp")
 
 env.Append(CPPPATH=[os.path.join(CUBISM_NATIVE_FRAMEWORK_DIR, "src")])
 

--- a/src/gd_cubism.hpp
+++ b/src/gd_cubism.hpp
@@ -54,6 +54,11 @@ const static char* PROP_PART_OPACITY_GROUP = "PartOpacity";
 
 const static char* SIGNAL_EFFECT_HIT_AREA_ENTERED = "hit_area_entered";
 const static char* SIGNAL_EFFECT_HIT_AREA_EXITED = "hit_area_exited";
+
+const static char* MOTION_FILE_EXTENSION = "motion3.json";
+const static char* EXPRESSION_FILE_EXTENSION = "exp3.json";
+const static char* MODEL_FILE_EXTENSION = "model3.json";
+
 #ifdef CUBISM_MOTION_CUSTOMDATA
 const static char* SIGNAL_MOTION_FINISHED = "motion_finished";
 #endif //CUBISM_MOTION_CUSTOMDATA

--- a/src/loaders/gd_cubism_motion_loader.cpp
+++ b/src/loaders/gd_cubism_motion_loader.cpp
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+#include <loaders/gd_cubism_motion_loader.hpp>
+
+#include <godot_cpp/classes/json.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+Variant GDCubismMotionLoader::_load(const String& p_path, const String& p_original_path, bool p_use_sub_threads, int32_t p_cache_mode) const {
+    String buffer = FileAccess::get_file_as_string(p_path);
+    ERR_FAIL_COND_V(buffer.is_empty(), Error::FAILED);
+
+    Dictionary motion = JSON::parse_string(buffer);
+    Dictionary meta = motion["Meta"];
+
+    Ref<Animation> anim;
+    anim.instantiate();
+
+    bool loop = meta.get("Loop", false);
+    anim->set_loop_mode(
+        loop
+        ? Animation::LOOP_LINEAR
+        : Animation::LOOP_NONE);
+    double fps = meta.get("FPS", 60.0);
+    anim->set_step(1.0 / fps);
+
+    // parse motion curves
+    Array curves = motion["Curves"];
+    for (uint32_t c_idx = 0; c_idx < curves.size(); c_idx++) {
+        Dictionary curve = curves[c_idx];
+
+        // TODO only support parameter type curves for now
+        if (curve["Target"] != "Parameter") {
+            continue;
+        }
+
+        String property = curve["Id"];
+        Array segments = curve["Segments"];
+
+        ERR_FAIL_COND_V_MSG(segments.size() < 2, nullptr, "Invalid Segment, must have at least one point");
+
+        int32_t track = anim->add_track(Animation::TYPE_BEZIER);
+        anim->track_set_path(track, NodePath(".:" + property));
+        anim->track_set_interpolation_loop_wrap(track, true);
+
+        // first key is always the starting time and value
+        anim->bezier_track_insert_key(track, segments[0], segments[1]);
+
+        // parsing techniques adapted from Unity Importer
+        // https://github.com/Live2D/CubismUnityComponents/blob/08815c83738ecdd8fe689f4222280540ff8ea9c8/Assets/Live2D/Cubism/Framework/Json/CubismMotion3Json.cs#L401
+        for (uint32_t s_idx = 2, last_key = anim->track_get_key_count(track) - 1; s_idx < segments.size();) {
+
+            int32_t type = segments[s_idx];
+            ERR_FAIL_COND_V_MSG(type < 0 || type > 3, nullptr, "Invalid Motion Segment Type");
+
+            real_t p0_t = segments[s_idx - 2];
+            real_t p0_v = segments[s_idx - 1];
+
+            if (type == 0) {
+                // LINEAR
+                real_t p1_t = segments[s_idx + 1];
+                real_t p1_v = segments[s_idx + 2];
+
+                // tangents
+                Vector2 out_t = Vector2(p1_t - p0_t, p1_v - p0_v);
+                Vector2 in_t = out_t * Vector2(-1, 1);
+
+                UtilityFunctions::print(out_t, in_t);
+
+                anim->bezier_track_set_key_out_handle(track, last_key, out_t);
+
+                last_key = anim->bezier_track_insert_key(
+                    track,
+                    p1_t, p1_v,
+                    in_t,
+                    Vector2(0, 0));
+
+                s_idx += 3;
+            }
+            else if (type == 1) {
+                // CUBIC BEZIER
+                real_t p1_t = segments[s_idx + 1];
+                real_t p1_v = segments[s_idx + 2];
+                real_t p2_t = segments[s_idx + 3];
+                real_t p2_v = segments[s_idx + 4];
+                real_t p3_t = segments[s_idx + 5];
+                real_t p3_v = segments[s_idx + 6];
+
+                real_t tangent_len = Math::absf(p0_t - p3_t) * 0.33333f;
+                Vector2 out_t = Vector2(tangent_len, p1_v - p0_v);
+                Vector2 in_t = Vector2(-tangent_len, p3_v - p2_v);
+
+                anim->bezier_track_set_key_out_handle(track, last_key, out_t);
+
+                last_key = anim->bezier_track_insert_key(
+                    track, p3_t, p3_v,
+                    in_t,
+                    Vector2(0, 0));
+
+                s_idx += 7;
+            }
+            else if (type == 2) {
+                // Stepped
+                real_t p1_t = segments[s_idx + 1];
+                real_t p1_v = segments[s_idx + 2];
+
+                last_key = anim->bezier_track_insert_key(
+                    track, p1_t, p1_v,
+                    Vector2(0, INFINITY));
+                s_idx += 3;
+            }
+            else if (type == 3) {
+                // Inverse Stepped
+                real_t p1_t = segments[s_idx + 1];
+                real_t p1_v = segments[s_idx + 2];
+
+                Vector2 out_t = Vector2(p1_t - p0_t, p1_v - p0_v);
+
+                anim->bezier_track_set_key_out_handle(track, last_key, out_t);
+
+                anim->bezier_track_insert_key(
+                    track, p0_t + 0.01f, p1_v,
+                    out_t,
+                    Vector2(0, 0));
+
+                last_key = anim->bezier_track_insert_key(
+                    track, p1_t, p1_v,
+                    Vector2(0, 0),
+                    Vector2(0, 0));
+
+                s_idx += 3;
+            }
+        }
+    }
+
+    double duration = meta.get("Duration", 1.0);
+    anim->set_length(duration);
+
+    return anim;
+}

--- a/src/loaders/gd_cubism_motion_loader.cpp
+++ b/src/loaders/gd_cubism_motion_loader.cpp
@@ -36,7 +36,7 @@ Variant GDCubismMotionLoader::_load(const String& p_path, const String& p_origin
         String property = curve["Id"];
         Array segments = curve["Segments"];
 
-        ERR_FAIL_COND_V_MSG(segments.size() < 2, nullptr, "Invalid Segment, must have at least one point");
+        ERR_FAIL_COND_V_MSG(segments.size() < 2, Error::FAILED, "Invalid Segment, must have at least one point");
 
         int32_t track = anim->add_track(Animation::TYPE_BEZIER);
         anim->track_set_path(track, NodePath(".:" + property));
@@ -50,7 +50,7 @@ Variant GDCubismMotionLoader::_load(const String& p_path, const String& p_origin
         for (uint32_t s_idx = 2, last_key = anim->track_get_key_count(track) - 1; s_idx < segments.size();) {
 
             int32_t type = segments[s_idx];
-            ERR_FAIL_COND_V_MSG(type < 0 || type > 3, nullptr, "Invalid Motion Segment Type");
+            ERR_FAIL_COND_V_MSG(type < 0 || type > 3, Error::FAILED, "Invalid Motion Segment Type");
 
             real_t p0_t = segments[s_idx - 2];
             real_t p0_v = segments[s_idx - 1];
@@ -134,6 +134,7 @@ Variant GDCubismMotionLoader::_load(const String& p_path, const String& p_origin
 
     double duration = meta.get("Duration", 1.0);
     anim->set_length(duration);
+    anim->set_path(p_path);
 
     return anim;
 }

--- a/src/loaders/gd_cubism_motion_loader.hpp
+++ b/src/loaders/gd_cubism_motion_loader.hpp
@@ -30,15 +30,19 @@ public:
     }
 
     bool _recognize_path(const String &p_path, const StringName &p_type) const override {
-        return p_path.ends_with(MOTION_FILE_EXTENSION) && ClassDB::is_parent_class(p_type, "Animation");
+        return p_path.ends_with(MOTION_FILE_EXTENSION);
     }
 
     bool _handles_type(const StringName &p_type) const override {
-        return p_type == StringName("Animation");
+        return ClassDB::is_parent_class(p_type, "Animation");
     }
 
     String _get_resource_type(const String &p_path) const override {
-        return "Animation";
+        if (p_path.ends_with(MOTION_FILE_EXTENSION)) {
+            return "Animation";
+        }
+            
+        return "";
     }
 
     bool _exists(const String &p_path) const override {

--- a/src/loaders/gd_cubism_motion_loader.hpp
+++ b/src/loaders/gd_cubism_motion_loader.hpp
@@ -1,0 +1,51 @@
+#ifndef GD_CUBISM_MOTION_LOADER
+#define GD_CUBISM_MOTION_LOADER
+
+// ----------------------------------------------------------------- include(s)
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/classes/global_constants.hpp>
+#include <godot_cpp/classes/resource_format_loader.hpp>
+#include <godot_cpp/classes/animation.hpp>
+#include <godot_cpp/classes/json.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include <gd_cubism.hpp>
+
+// ------------------------------------------------------------------ define(s)
+// --------------------------------------------------------------- namespace(s)
+using namespace godot;
+
+class GDCubismMotionLoader : public ResourceFormatLoader {
+    GDCLASS(GDCubismMotionLoader, ResourceFormatLoader);
+
+protected:
+    static void _bind_methods() {}
+
+public:
+    PackedStringArray _get_recognized_extensions() const override {
+        PackedStringArray ext;
+        ext.append(MOTION_FILE_EXTENSION);
+        return ext;
+    }
+
+    bool _recognize_path(const String &p_path, const StringName &p_type) const override {
+        return p_path.ends_with(MOTION_FILE_EXTENSION) && ClassDB::is_parent_class(p_type, "Animation");
+    }
+
+    bool _handles_type(const StringName &p_type) const override {
+        return p_type == StringName("Animation");
+    }
+
+    String _get_resource_type(const String &p_path) const override {
+        return "Animation";
+    }
+
+    bool _exists(const String &p_path) const override {
+        return FileAccess::file_exists(p_path);
+    }
+    
+    Variant _load(const String &p_path, const String &p_original_path, bool p_use_sub_threads, int32_t p_cache_mode) const override;
+};
+
+#endif // GD_CUBISM_MOTION_LOADER

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,0 +1,9 @@
+#include <plugin.hpp>
+
+using namespace godot;
+
+void GDCubismPlugin::_enter_tree() {
+}
+
+void GDCubismPlugin::_exit_tree() {
+}

--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+#ifndef GD_CUBISM_PLUGIN
+#define GD_CUBISM_PLUGIN
+// ----------------------------------------------------------------- include(s)
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/classes/global_constants.hpp>
+#include <godot_cpp/classes/editor_plugin.hpp>
+#include <godot_cpp/classes/animation.hpp>
+
+using namespace godot;
+
+class GDCubismPlugin : public EditorPlugin {
+    GDCLASS(GDCubismPlugin, EditorPlugin);
+
+protected:
+    static void _bind_methods() {};
+
+public:
+    void _enter_tree() override;
+    void _exit_tree() override;
+};
+
+#endif // GD_CUBISM_PLUGIN

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -2,10 +2,13 @@
 // SPDX-FileCopyrightText: 2023 MizunagiKB <mizukb@live.jp>
 // ----------------------------------------------------------------- include(s)
 #include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/classes/editor_plugin_registration.hpp>
+#include <godot_cpp/classes/resource_loader.hpp>
 #include <gdextension_interface.h>
 
 #include <CubismFramework.hpp>
 
+#include <loaders/gd_cubism_motion_loader.hpp>
 #include <private/internal_cubism_allocator.hpp>
 #include <gd_cubism_effect.hpp>
 #include <gd_cubism_effect_breath.hpp>
@@ -19,40 +22,43 @@
 #include <gd_cubism_value_part_opacity.hpp>
 #include <gd_cubism_user_model.hpp>
 #include <register_types.hpp>
-
+#include <plugin.hpp>
 
 // --------------------------------------------------------------- namespace(s)
 using namespace godot;
 
-
 static InternalCubismAllocator allocator;
 static Csm::CubismFramework::Option option;
 
+static Ref<GDCubismMotionLoader> motionLoader;
 
 // -------------------------------------------------------------------- enum(s)
 // ------------------------------------------------------------------- const(s)
 // ----------------------------------------------------------- class:forward(s)
 // ------------------------------------------------------------------- class(s)
 // ------------------------------------------------------------------ method(s)
-void output(const char* message) {
+void output(const char *message) {
     #ifdef DEBUG_ENABLED
     WARN_PRINT(message);
-    #endif // DEBUG_ENABLED    
+    #endif // DEBUG_ENABLED
 }
 
-
 void initialize_gd_cubism_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+    if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+        ClassDB::register_class<GDCubismPlugin>();
+        EditorPlugins::add_by_type<GDCubismPlugin>();
+    }
 
+    if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+        return;
+    }
     option.LogFunction = output;
 
     #ifdef DEBUG_ENABLED
     option.LoggingLevel = Csm::CubismFramework::Option::LogLevel::LogLevel_Verbose;
     #else
     option.LoggingLevel = Csm::CubismFramework::Option::LogLevel::LogLevel_Off;
-    #endif // DEBUG_ENABLED  
+    #endif // DEBUG_ENABLED
 
     Csm::CubismFramework::StartUp(&allocator, &option);
     Csm::CubismFramework::Initialize();
@@ -67,34 +73,43 @@ void initialize_gd_cubism_module(ModuleInitializationLevel p_level) {
     GDREGISTER_VIRTUAL_CLASS(GDCubismValueAbs);
     GDREGISTER_CLASS(GDCubismParameter);
     GDREGISTER_CLASS(GDCubismPartOpacity);
-    
 
+    ClassDB::register_class<GDCubismMotionLoader>();
     ClassDB::register_class<GDCubismMotionQueueEntryHandle>();
     ClassDB::register_class<GDCubismMotionEntry>();
     ClassDB::register_class<GDCubismUserModel>();
+
+    motionLoader.instantiate();
+
+    // prioritize our format loaders so that the more generic json loader isn't preferred
+    ResourceLoader::get_singleton()->add_resource_format_loader(motionLoader, true);
 }
 
-
 void uninitialize_gd_cubism_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+    if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+        EditorPlugins::remove_by_type<GDCubismPlugin>();
+    }
+    
+    if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
 
+    ResourceLoader::get_singleton()->remove_resource_format_loader(motionLoader);
+    motionLoader.unref();
+    
     Csm::CubismFramework::Dispose();
 }
 
-
 extern "C" {
 
-// GDCubism init.
-GDExtensionBool GDE_EXPORT gd_cubism_library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
-    godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
+    // GDCubism init.
+    GDExtensionBool GDE_EXPORT gd_cubism_library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+        godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
 
-    init_obj.register_initializer(initialize_gd_cubism_module);
-    init_obj.register_terminator(uninitialize_gd_cubism_module);
-    init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
+        init_obj.register_initializer(initialize_gd_cubism_module);
+        init_obj.register_terminator(uninitialize_gd_cubism_module);
+        init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
 
-    return init_obj.init();
-}
-
+        return init_obj.init();
+    }
 }


### PR DESCRIPTION
- Introduces GDCubismPlugin for managing editor plugins in the project
- Introduces GDCubismMotionImporter, which is registered as an EditorImporterPlugin for json files ("model3.json" specifically) to convert them to binary "anim" Resources
- GDCubismMotionImporter can be used at runtime with its `parse_motion` function, allowing for motions to be loaded from outside of the project directory

To use the motions, one can add an AnimationPlayer to a GDCubismUserModel, then create an AnimationLibrary that references the resources.  It is recommended to set parameter mode to NoneParameter, so that motions can not be played through the SDK when using this approach.   As imported resources, the motions are read-only within Godot.

This PR lays the groundwork of #127, deprecating motion playback directly through the SDK.
Another PR will be introduced at a later time to remove the motion controls from GDCubismUserModel in favor of AnimationPlayer.

https://github.com/user-attachments/assets/6bc932fb-40f7-4fdc-a7a2-c83df9061ce3
