### PR TITLE
Direct rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ docs-site/node_modules
 docs-site/package-lock.json
 docs-site/package.json
 
+# for Node
+node_modules
+package-lock.json
+package.json
+
+
 # for Experimental
 thirdparty/CubismNativeFramework
 thirdparty/CubismSdkForNative*

--- a/SConspage
+++ b/SConspage
@@ -34,7 +34,7 @@ def build():
     env.Command(
         source="./docs-site/antora-playbook.yml",
         target="./docs",
-        action=["antora --fetch $SOURCE"],
+        action=["npx antora --fetch $SOURCE"],
     )
     env.Command(target="./docs/.nojekyll", source=None, action="touch ./docs/.nojekyll")
 

--- a/demo/addons/gd_cubism/cs/gd_cubism_user_model_cs.cs
+++ b/demo/addons/gd_cubism/cs/gd_cubism_user_model_cs.cs
@@ -186,6 +186,17 @@ public partial class GDCubismUserModelCS : GodotObject
     }
 
     /// <value>
+    ///     Property <c>PhysicsEvaluate</c>
+    ///     <br />
+    ///     Setting this parameter to `false` disables physical calculations.
+    /// </value>
+    public bool PhysicsEvaluate
+    {
+        set { this.InternalObject.Call("set_physics_evaluate", value); }
+        get { return (bool)this.InternalObject.Call("get_physics_evaluate"); }
+    }
+
+    /// <value>
     ///     Property <c>PlaybackProcessMode</c>
     ///     <br />
     ///     Specifies the playback method for the currently held Live2D model.
@@ -198,6 +209,18 @@ public partial class GDCubismUserModelCS : GodotObject
             int value = (int)this.InternalObject.Call("get_process_callback");
             return (MotionProcessCallbackEnum)Enum.ToObject(typeof(MotionProcessCallbackEnum), value);
         }
+    }
+
+    /// <value>
+    ///     Property <c>PoseUpdate</c>
+    ///     <br />
+    ///     Setting this parameter to `false` disables transparency calculations between drawing parts specified in the pose group.
+    ///     If you want to manually handle all transparency calculations, set this parameter to `false`.
+    /// </value>
+    public bool PoseUpdate
+    {
+        set { this.InternalObject.Call("set_pose_update", value); }
+        get { return (bool)this.InternalObject.Call("get_pose_update"); }
     }
 
     public Shader ShaderAdd

--- a/demo/addons/gd_cubism/example/custom_efx_02.gd
+++ b/demo/addons/gd_cubism/example/custom_efx_02.gd
@@ -18,8 +18,8 @@ func _on_cubism_process(model: GDCubismUserModel, delta: float):
     if dict_mesh.has(art_mesh_name) == false:
         return
 
-    var ary_mesh: ArrayMesh = dict_mesh[art_mesh_name]
-    var ary_surface: Array = ary_mesh.surface_get_arrays(0)
+    var ary_mesh: MeshInstance2D = dict_mesh[art_mesh_name]
+    var ary_surface: Array = ary_mesh.mesh.surface_get_arrays(0)
     var mesh_vertex: PackedVector2Array = ary_surface[ArrayMesh.ARRAY_VERTEX]
 
     if first_time == true:
@@ -34,6 +34,6 @@ func _on_cubism_process(model: GDCubismUserModel, delta: float):
     var calc_vct = (to - fr)
     var scale: float = calc_vct.length() / base_vct.length()
 
-    $Sprite2D.position = fr
+    $Sprite2D.position = model.to_global(fr)
     $Sprite2D.rotation = base_vct.normalized().cross(calc_vct.normalized())
     $Sprite2D.scale = base_scale * scale

--- a/demo/addons/gd_cubism/example/demo_effect_custom_01.gd
+++ b/demo/addons/gd_cubism/example/demo_effect_custom_01.gd
@@ -1,6 +1,9 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2023 MizunagiKB <mizukb@live.jp>
 extends Node2D
 
 
+const DEFAULT_ASSET: String = "res://addons/gd_cubism/example/res/live2d/mao_pro_jp/runtime/mao_pro.model3.json"
 enum E_PARAM_MODE {
     PROCESS,
     SIGNAL
@@ -12,13 +15,29 @@ var l_eye: GDCubismParameter
 var r_eye: GDCubismParameter
 
 
+func recalc_model_position(model: GDCubismUserModel):
+    if model.assets == "":
+        return
+
+    var canvas_info: Dictionary = model.get_canvas_info()
+
+    if canvas_info.is_empty() != true:
+        var vct_viewport_size = Vector2(get_viewport_rect().size)
+        var scale: float = vct_viewport_size.y / max(canvas_info.size_in_pixels.x, canvas_info.size_in_pixels.y)
+        model.position = vct_viewport_size / 2.0
+        model.scale = Vector2(scale, scale)
+
+
 func _ready():
-    pass
+    if $GDCubismUserModel.assets == "":
+        $GDCubismUserModel.assets = DEFAULT_ASSET
 
 
 func _process(delta):
+    recalc_model_position($GDCubismUserModel)
+
     if param_mode == E_PARAM_MODE.PROCESS:
-        var model: GDCubismUserModel = $Sprite2D/GDCubismUserModel
+        var model: GDCubismUserModel = $GDCubismUserModel
 
         for _o in model.get_parameters():
             var o: GDCubismParameter = _o

--- a/demo/addons/gd_cubism/example/demo_effect_custom_01.tscn
+++ b/demo/addons/gd_cubism/example/demo_effect_custom_01.tscn
@@ -5,20 +5,14 @@
 [node name="demo_effect_custom_01" type="Node2D"]
 script = ExtResource("1_2sdfp")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2(640, 512)
+[node name="GDCubismUserModel" type="GDCubismUserModel" parent="."]
+position = Vector2(640, 360)
+scale = Vector2(0.075, 0.075)
 
-[node name="GDCubismUserModel" type="GDCubismUserModel" parent="Sprite2D"]
-disable_3d = true
-transparent_bg = true
-gui_disable_input = true
-size = Vector2i(1024, 1024)
-render_target_update_mode = 4
+[node name="GDCubismEffectCustom" type="GDCubismEffectCustom" parent="GDCubismUserModel"]
 
-[node name="GDCubismEffectCustom" type="GDCubismEffectCustom" parent="Sprite2D/GDCubismUserModel"]
-
-[connection signal="cubism_epilogue" from="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" to="." method="_on_gd_cubism_effect_custom_cubism_epilogue"]
-[connection signal="cubism_init" from="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" to="." method="_on_gd_cubism_effect_custom_cubism_init"]
-[connection signal="cubism_process" from="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" to="." method="_on_gd_cubism_effect_custom_cubism_process"]
-[connection signal="cubism_prologue" from="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" to="." method="_on_gd_cubism_effect_custom_cubism_prologue"]
-[connection signal="cubism_term" from="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" to="." method="_on_gd_cubism_effect_custom_cubism_term"]
+[connection signal="cubism_epilogue" from="GDCubismUserModel/GDCubismEffectCustom" to="." method="_on_gd_cubism_effect_custom_cubism_epilogue"]
+[connection signal="cubism_init" from="GDCubismUserModel/GDCubismEffectCustom" to="." method="_on_gd_cubism_effect_custom_cubism_init"]
+[connection signal="cubism_process" from="GDCubismUserModel/GDCubismEffectCustom" to="." method="_on_gd_cubism_effect_custom_cubism_process"]
+[connection signal="cubism_prologue" from="GDCubismUserModel/GDCubismEffectCustom" to="." method="_on_gd_cubism_effect_custom_cubism_prologue"]
+[connection signal="cubism_term" from="GDCubismUserModel/GDCubismEffectCustom" to="." method="_on_gd_cubism_effect_custom_cubism_term"]

--- a/demo/addons/gd_cubism/example/demo_effect_custom_02.tscn
+++ b/demo/addons/gd_cubism/example/demo_effect_custom_02.tscn
@@ -3,24 +3,18 @@
 [ext_resource type="Script" path="res://addons/gd_cubism/example/custom_efx_02.gd" id="1_ittjg"]
 [ext_resource type="Texture2D" uid="uid://c8o4yd28cp3jy" path="res://icon.svg" id="2_0d7x8"]
 
-[node name="demo_effect_custom_01" type="Node2D"]
+[node name="demo_effect_custom_02" type="Node2D"]
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2(640, 512)
+[node name="GDCubismUserModel" type="GDCubismUserModel" parent="."]
+position = Vector2(640, 360)
+scale = Vector2(0.075, 0.075)
 
-[node name="GDCubismUserModel" type="GDCubismUserModel" parent="Sprite2D"]
-disable_3d = true
-transparent_bg = true
-gui_disable_input = true
-size = Vector2i(1024, 1024)
-render_target_update_mode = 4
-
-[node name="GDCubismEffectCustom" type="GDCubismEffectCustom" parent="Sprite2D/GDCubismUserModel"]
+[node name="GDCubismEffectCustom" type="GDCubismEffectCustom" parent="GDCubismUserModel"]
 script = ExtResource("1_ittjg")
 
-[node name="Sprite2D" type="Sprite2D" parent="Sprite2D/GDCubismUserModel/GDCubismEffectCustom"]
+[node name="Sprite2D" type="Sprite2D" parent="GDCubismUserModel/GDCubismEffectCustom"]
 z_index = 1024
 scale = Vector2(0.5, 0.5)
 texture = ExtResource("2_0d7x8")
 
-[connection signal="cubism_process" from="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" to="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" method="_on_cubism_process"]
+[connection signal="cubism_process" from="GDCubismUserModel/GDCubismEffectCustom" to="GDCubismUserModel/GDCubismEffectCustom" method="_on_cubism_process"]

--- a/demo/addons/gd_cubism/example/demo_effect_custom_03.tscn
+++ b/demo/addons/gd_cubism/example/demo_effect_custom_03.tscn
@@ -1,30 +1,20 @@
-[gd_scene load_steps=3 format=3 uid="uid://xk7rqvf532rj"]
+[gd_scene load_steps=2 format=3 uid="uid://xk7rqvf532rj"]
 
 [ext_resource type="Script" path="res://addons/gd_cubism/example/custom_efx_03.gd" id="1_lh0xb"]
 
-[sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_w6cby"]
-blend_mode = 4
-light_mode = 1
+[node name="demo_effect_custom_03" type="Node2D"]
 
-[node name="demo_effect_custom_02" type="Node2D"]
+[node name="GDCubismUserModel" type="GDCubismUserModel" parent="."]
+position = Vector2(640, 360)
+scale = Vector2(0.075, 0.075)
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
-material = SubResource("CanvasItemMaterial_w6cby")
-position = Vector2(256, 256)
-
-[node name="GDCubismUserModel" type="GDCubismUserModel" parent="Sprite2D"]
-disable_3d = true
-transparent_bg = true
-gui_disable_input = true
-render_target_update_mode = 4
-
-[node name="GDCubismEffectCustom" type="GDCubismEffectCustom" parent="Sprite2D/GDCubismUserModel"]
+[node name="GDCubismEffectCustom" type="GDCubismEffectCustom" parent="GDCubismUserModel"]
 script = ExtResource("1_lh0xb")
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
 autoplay = true
 bus = &"Voice"
 
-[connection signal="cubism_init" from="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" to="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" method="_on_cubism_init"]
-[connection signal="cubism_process" from="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" to="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" method="_on_cubism_process"]
-[connection signal="cubism_term" from="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" to="Sprite2D/GDCubismUserModel/GDCubismEffectCustom" method="_on_cubism_term"]
+[connection signal="cubism_init" from="GDCubismUserModel/GDCubismEffectCustom" to="GDCubismUserModel/GDCubismEffectCustom" method="_on_cubism_init"]
+[connection signal="cubism_process" from="GDCubismUserModel/GDCubismEffectCustom" to="GDCubismUserModel/GDCubismEffectCustom" method="_on_cubism_process"]
+[connection signal="cubism_term" from="GDCubismUserModel/GDCubismEffectCustom" to="GDCubismUserModel/GDCubismEffectCustom" method="_on_cubism_term"]

--- a/demo/addons/gd_cubism/example/demo_effect_hit_area.gd
+++ b/demo/addons/gd_cubism/example/demo_effect_hit_area.gd
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2023 MizunagiKB <mizukb@live.jp>
 extends Node2D
 
 
@@ -11,34 +13,46 @@ var dict_pickup: Dictionary
 var id_mesh: String = ""
 
 
+func recalc_model_position(model: GDCubismUserModel):
+    if model.assets == "":
+        return
+
+    var canvas_info: Dictionary = model.get_canvas_info()
+
+    if canvas_info.is_empty() != true:
+        var vct_viewport_size = Vector2(get_viewport_rect().size)
+        var scale: float = vct_viewport_size.y / max(canvas_info.size_in_pixels.x, canvas_info.size_in_pixels.y)
+        model.position = vct_viewport_size / 2.0
+        model.scale = Vector2(scale, scale)
+
+
 func _ready():
 
-    if $Sprite2D/GDCubismUserModel.assets == "":
-        $Sprite2D/GDCubismUserModel.assets = DEFAULT_ASSET
+    if $GDCubismUserModel.assets == "":
+        $GDCubismUserModel.assets = DEFAULT_ASSET
 
     $Control/ItemList.clear()
-    for id in $Sprite2D/GDCubismUserModel.get_meshes():
+    for id in $GDCubismUserModel.get_meshes():
         $Control/ItemList.add_item(id)
 
 
 func _process(delta):
 
-    if $Sprite2D.centered == true:
-        adjust_pos = ($Sprite2D/GDCubismUserModel.size * 0.5)
+    recalc_model_position($GDCubismUserModel)
 
     if pressed == true:
-        $Sprite2D/GDCubismUserModel/GDCubismEffectHitArea.set_target(local_pos)
+        $GDCubismUserModel/GDCubismEffectHitArea.set_target(local_pos)
 
     $Control/lbl_mouse_x.text = "%6.3f" % local_pos.x
     $Control/lbl_mouse_y.text = "%6.3f" % local_pos.y
 
     if id_mesh != "":
-        dict_pickup = $Sprite2D/GDCubismUserModel/GDCubismEffectHitArea.get_detail(
-            $Sprite2D/GDCubismUserModel,
+        dict_pickup = $GDCubismUserModel/GDCubismEffectHitArea.get_detail(
+            $GDCubismUserModel,
             id_mesh
         )
 
-    $Sprite2D/Canvas.queue_redraw()
+    $Canvas.queue_redraw()
 
 
 func _input(event):
@@ -47,24 +61,32 @@ func _input(event):
         pressed = event.is_pressed()
 
     if event as InputEventMouseMotion:
-        local_pos = $Sprite2D.to_local(event.position) + adjust_pos
+        local_pos = event.position - $GDCubismUserModel.position
+        local_pos = local_pos * (Vector2.ONE / $GDCubismUserModel.scale)
 
 
 func mark_hit_area(dict_hit_area: Dictionary, color_box: Color, color_tri: Color):
 
     if dict_hit_area.is_empty() == false:
-        var r: Rect2 = Rect2(dict_hit_area.rect.position - adjust_pos, dict_hit_area.rect.size)
-        $Sprite2D/Canvas.draw_rect(r, color_box, false, 5)
+        var r: Rect2 = Rect2(
+            (dict_hit_area.rect.position - adjust_pos) * $GDCubismUserModel.scale,
+            dict_hit_area.rect.size * $GDCubismUserModel.scale
+        )
+        $Canvas.draw_rect(r, color_box, false, 5)
 
         if dict_hit_area.has("vertices") == true:
-            var v = dict_hit_area.vertices
-            $Sprite2D/Canvas.draw_line(v[0] - adjust_pos, v[1] - adjust_pos, color_tri, 3)
-            $Sprite2D/Canvas.draw_line(v[1] - adjust_pos, v[2] - adjust_pos, color_tri, 3)
-            $Sprite2D/Canvas.draw_line(v[2] - adjust_pos, v[0] - adjust_pos, color_tri, 3)
+            var v: Array[Vector2]
+            v.resize(3)
+            v[0] = dict_hit_area.vertices[0] * $GDCubismUserModel.scale
+            v[1] = dict_hit_area.vertices[1] * $GDCubismUserModel.scale
+            v[2] = dict_hit_area.vertices[2] * $GDCubismUserModel.scale
+            $Canvas.draw_line(v[0] - adjust_pos, v[1] - adjust_pos, color_tri, 3)
+            $Canvas.draw_line(v[1] - adjust_pos, v[2] - adjust_pos, color_tri, 3)
+            $Canvas.draw_line(v[2] - adjust_pos, v[0] - adjust_pos, color_tri, 3)
 
 
 func _on_gd_cubism_effect_hit_area_hit_area_entered(model, id):
-    dict_detail = $Sprite2D/GDCubismUserModel/GDCubismEffectHitArea.get_detail(model, id)
+    dict_detail = $GDCubismUserModel/GDCubismEffectHitArea.get_detail(model, id)
     $Control/lbl_id.text = id
 
 

--- a/demo/addons/gd_cubism/example/demo_effect_hit_area.gd
+++ b/demo/addons/gd_cubism/example/demo_effect_hit_area.gd
@@ -27,7 +27,6 @@ func recalc_model_position(model: GDCubismUserModel):
 
 
 func _ready():
-
     if $GDCubismUserModel.assets == "":
         $GDCubismUserModel.assets = DEFAULT_ASSET
 
@@ -37,7 +36,6 @@ func _ready():
 
 
 func _process(delta):
-
     recalc_model_position($GDCubismUserModel)
 
     if pressed == true:
@@ -56,17 +54,14 @@ func _process(delta):
 
 
 func _input(event):
-
     if event as InputEventMouseButton:
         pressed = event.is_pressed()
 
     if event as InputEventMouseMotion:
-        local_pos = event.position - $GDCubismUserModel.position
-        local_pos = local_pos * (Vector2.ONE / $GDCubismUserModel.scale)
+        local_pos = $GDCubismUserModel.to_local(event.position)
 
 
 func mark_hit_area(dict_hit_area: Dictionary, color_box: Color, color_tri: Color):
-
     if dict_hit_area.is_empty() == false:
         var r: Rect2 = Rect2(
             (dict_hit_area.rect.position - adjust_pos) * $GDCubismUserModel.scale,
@@ -75,11 +70,11 @@ func mark_hit_area(dict_hit_area: Dictionary, color_box: Color, color_tri: Color
         $Canvas.draw_rect(r, color_box, false, 5)
 
         if dict_hit_area.has("vertices") == true:
-            var v: Array[Vector2]
-            v.resize(3)
-            v[0] = dict_hit_area.vertices[0] * $GDCubismUserModel.scale
-            v[1] = dict_hit_area.vertices[1] * $GDCubismUserModel.scale
-            v[2] = dict_hit_area.vertices[2] * $GDCubismUserModel.scale
+            var v: Array[Vector2] = [
+                dict_hit_area.vertices[0] * $GDCubismUserModel.scale,
+                dict_hit_area.vertices[1] * $GDCubismUserModel.scale,
+                dict_hit_area.vertices[2] * $GDCubismUserModel.scale
+            ]
             $Canvas.draw_line(v[0] - adjust_pos, v[1] - adjust_pos, color_tri, 3)
             $Canvas.draw_line(v[1] - adjust_pos, v[2] - adjust_pos, color_tri, 3)
             $Canvas.draw_line(v[2] - adjust_pos, v[0] - adjust_pos, color_tri, 3)

--- a/demo/addons/gd_cubism/example/demo_effect_hit_area.gd
+++ b/demo/addons/gd_cubism/example/demo_effect_hit_area.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 
-const DEFAULT_ASSET: String = "res://addons/gd_cubism/example/res/live2d/mao_pro_jp/runtime/mao_pro_t02.model3.json"
+const DEFAULT_ASSET: String = "res://addons/gd_cubism/example/res/live2d/mao_pro_jp/runtime/mao_pro.model3.json"
 
 var pressed: bool = false
 var local_pos: Vector2 = Vector2.ZERO
@@ -80,4 +80,3 @@ func _on_canvas_draw():
 
 func _on_item_list_item_selected(index):
     id_mesh = $Control/ItemList.get_item_text(index)
-

--- a/demo/addons/gd_cubism/example/demo_effect_hit_area.tscn
+++ b/demo/addons/gd_cubism/example/demo_effect_hit_area.tscn
@@ -19,7 +19,6 @@ gui_disable_input = true
 render_target_update_mode = 4
 
 [node name="GDCubismEffectHitArea" type="GDCubismEffectHitArea" parent="Sprite2D/GDCubismUserModel"]
-monitoring = false
 
 [node name="Canvas" type="Control" parent="Sprite2D"]
 layout_mode = 3

--- a/demo/addons/gd_cubism/example/demo_effect_hit_area.tscn
+++ b/demo/addons/gd_cubism/example/demo_effect_hit_area.tscn
@@ -1,28 +1,23 @@
-[gd_scene load_steps=3 format=3 uid="uid://bgus7rihdnj0q"]
+[gd_scene load_steps=2 format=3 uid="uid://bgus7rihdnj0q"]
 
 [ext_resource type="Script" path="res://addons/gd_cubism/example/demo_effect_hit_area.gd" id="1_v15iy"]
-
-[sub_resource type="ViewportTexture" id="ViewportTexture_x3u78"]
-viewport_path = NodePath("Sprite2D/GDCubismUserModel")
 
 [node name="demo_effect_hit_area" type="Node2D"]
 script = ExtResource("1_v15iy")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
+[node name="GDCubismUserModel" type="GDCubismUserModel" parent="."]
 position = Vector2(640, 360)
-texture = SubResource("ViewportTexture_x3u78")
 
-[node name="GDCubismUserModel" type="GDCubismUserModel" parent="Sprite2D"]
-disable_3d = true
-transparent_bg = true
-gui_disable_input = true
-render_target_update_mode = 4
+[node name="GDCubismEffectHitArea" type="GDCubismEffectHitArea" parent="GDCubismUserModel"]
 
-[node name="GDCubismEffectHitArea" type="GDCubismEffectHitArea" parent="Sprite2D/GDCubismUserModel"]
-
-[node name="Canvas" type="Control" parent="Sprite2D"]
+[node name="Canvas" type="Control" parent="."]
+z_index = 1024
 layout_mode = 3
 anchors_preset = 0
+offset_left = 640.0
+offset_top = 360.0
+offset_right = 640.0
+offset_bottom = 360.0
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 3
@@ -87,7 +82,7 @@ offset_bottom = -32.0
 grow_horizontal = 0
 grow_vertical = 2
 
-[connection signal="hit_area_entered" from="Sprite2D/GDCubismUserModel/GDCubismEffectHitArea" to="." method="_on_gd_cubism_effect_hit_area_hit_area_entered"]
-[connection signal="hit_area_exited" from="Sprite2D/GDCubismUserModel/GDCubismEffectHitArea" to="." method="_on_gd_cubism_effect_hit_area_hit_area_exited"]
-[connection signal="draw" from="Sprite2D/Canvas" to="." method="_on_canvas_draw"]
+[connection signal="hit_area_entered" from="GDCubismUserModel/GDCubismEffectHitArea" to="." method="_on_gd_cubism_effect_hit_area_hit_area_entered"]
+[connection signal="hit_area_exited" from="GDCubismUserModel/GDCubismEffectHitArea" to="." method="_on_gd_cubism_effect_hit_area_hit_area_exited"]
+[connection signal="draw" from="Canvas" to="." method="_on_canvas_draw"]
 [connection signal="item_selected" from="Control/ItemList" to="." method="_on_item_list_item_selected"]

--- a/demo/addons/gd_cubism/example/demo_effect_target_point.gd
+++ b/demo/addons/gd_cubism/example/demo_effect_target_point.gd
@@ -3,15 +3,14 @@
 extends Node2D
 
 
-const DEFAULT_ASSET: String = "res://addons/gd_cubism/example/res/live2d/mao_pro_jp/runtime/mao_pro_t02.model3.json"
+const DEFAULT_ASSET: String = "res://addons/gd_cubism/example/res/live2d/mao_pro_jp/runtime/mao_pro.model3.json"
 
 var pressed: bool = false
 
 
 func _ready():
-    
-    if $Sprite2D/GDCubismUserModel.assets == "":
-        $Sprite2D/GDCubismUserModel.assets = DEFAULT_ASSET
+    if $GDCubismUserModel.assets == "":
+        $GDCubismUserModel.assets = DEFAULT_ASSET
 
 
 func _process(delta):
@@ -19,20 +18,12 @@ func _process(delta):
 
 
 func _input(event):
-
     if event as InputEventMouseButton:
         pressed = event.is_pressed()
 
     if event as InputEventMouseMotion:
         if pressed == true:
-            # Convert to local position.
-            var local_pos = $Sprite2D.to_local(event.position)
-            # Adjust position.
-            var render_size: Vector2 = Vector2(
-                float($Sprite2D/GDCubismUserModel.size.x) * $Sprite2D.scale.x,
-                float($Sprite2D/GDCubismUserModel.size.y) * $Sprite2D.scale.y * -1.0
-            )
-            local_pos /= (render_size * 0.5)
-            $Sprite2D/GDCubismUserModel/GDCubismEffectTargetPoint.set_target(local_pos)
+            var calc_pos: Vector2 = $GDCubismUserModel.to_local(event.position) * Vector2(1, -1)
+            $GDCubismUserModel/GDCubismEffectTargetPoint.set_target(calc_pos.normalized())
         else:
-            $Sprite2D/GDCubismUserModel/GDCubismEffectTargetPoint.set_target(Vector2.ZERO)
+            $GDCubismUserModel/GDCubismEffectTargetPoint.set_target(Vector2.ZERO)

--- a/demo/addons/gd_cubism/example/demo_effect_target_point.tscn
+++ b/demo/addons/gd_cubism/example/demo_effect_target_point.tscn
@@ -5,13 +5,8 @@
 [node name="demo_effect_custom_03" type="Node2D"]
 script = ExtResource("1_j4tk3")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
+[node name="GDCubismUserModel" type="GDCubismUserModel" parent="."]
 position = Vector2(640, 360)
+scale = Vector2(0.075, 0.075)
 
-[node name="GDCubismUserModel" type="GDCubismUserModel" parent="Sprite2D"]
-disable_3d = true
-transparent_bg = true
-gui_disable_input = true
-render_target_update_mode = 4
-
-[node name="GDCubismEffectTargetPoint" type="GDCubismEffectTargetPoint" parent="Sprite2D/GDCubismUserModel"]
+[node name="GDCubismEffectTargetPoint" type="GDCubismEffectTargetPoint" parent="GDCubismUserModel"]

--- a/demo/addons/gd_cubism/example/demo_fade.gd
+++ b/demo/addons/gd_cubism/example/demo_fade.gd
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 MizunagiKB <mizukb@live.jp>
+extends Node2D
+
+
+const DEFAULT_ASSET: String = "res://addons/gd_cubism/example/res/live2d/mao_pro_jp/runtime/mao_pro.model3.json"
+
+
+func recalc_model_position(model: GDCubismUserModel):
+    if model.assets == "":
+        return
+
+    var canvas_info: Dictionary = model.get_canvas_info()
+
+    if canvas_info.is_empty() != true:
+        var vct_viewport_size = Vector2(get_viewport_rect().size)
+        var scale: float = vct_viewport_size.y / max(canvas_info.size_in_pixels.x, canvas_info.size_in_pixels.y)
+        model.position = vct_viewport_size / 2.0
+        model.scale = Vector2(scale, scale)
+
+
+func _ready() -> void:
+    if $GDCubismUserModel.assets == "":
+        $GDCubismUserModel.assets = DEFAULT_ASSET
+
+    if $Sprite2D/SubViewport/GDCubismUserModel.assets == "":
+        $Sprite2D/SubViewport/GDCubismUserModel.assets = DEFAULT_ASSET
+
+    $CheckBox.button_pressed = $GDCubismUserModel.pose_update
+
+
+func _process(delta: float) -> void:
+    pass
+
+
+func _on_h_slider_value_changed(value: float) -> void:
+    $Sprite2D.modulate = Color(1.0, 1.0, 1.0, value / 100.0)
+
+    for o in $GDCubismUserModel.get_part_opacities():
+        o.value = value / 100.0
+
+
+func _on_check_box_toggled(toggled_on: bool) -> void:
+    $GDCubismUserModel.pose_update = toggled_on

--- a/demo/addons/gd_cubism/example/demo_fade.tscn
+++ b/demo/addons/gd_cubism/example/demo_fade.tscn
@@ -1,0 +1,63 @@
+[gd_scene load_steps=3 format=3 uid="uid://rdteqxrmttct"]
+
+[ext_resource type="Script" path="res://addons/gd_cubism/example/demo_fade.gd" id="1_3vqxl"]
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_nt5uq"]
+viewport_path = NodePath("Sprite2D/SubViewport")
+
+[node name="demo_fade" type="Node2D"]
+script = ExtResource("1_3vqxl")
+metadata/_edit_vertical_guides_ = [640.0, 320.0, 960.0]
+metadata/_edit_horizontal_guides_ = [640.0]
+
+[node name="Label1" type="Label" parent="."]
+offset_top = 640.0
+offset_right = 640.0
+offset_bottom = 704.0
+text = "Direct Rendering"
+horizontal_alignment = 1
+vertical_alignment = 2
+
+[node name="GDCubismUserModel" type="GDCubismUserModel" parent="."]
+position = Vector2(320, 360)
+scale = Vector2(0.075, 0.075)
+
+[node name="Label2" type="Label" parent="."]
+offset_left = 640.0
+offset_top = 640.0
+offset_right = 1280.0
+offset_bottom = 703.0
+text = "SubViewport"
+horizontal_alignment = 1
+vertical_alignment = 2
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(960, 512)
+texture = SubResource("ViewportTexture_nt5uq")
+
+[node name="SubViewport" type="SubViewport" parent="Sprite2D"]
+disable_3d = true
+transparent_bg = true
+size = Vector2i(512, 1024)
+
+[node name="GDCubismUserModel" type="GDCubismUserModel" parent="Sprite2D/SubViewport"]
+position = Vector2(256, 360)
+scale = Vector2(0.075, 0.075)
+
+[node name="HSlider" type="HSlider" parent="."]
+offset_left = 16.0
+offset_top = 16.0
+offset_right = 1264.0
+offset_bottom = 48.0
+value = 100.0
+
+[node name="CheckBox" type="CheckBox" parent="."]
+offset_left = 16.0
+offset_top = 64.0
+offset_right = 176.0
+offset_bottom = 104.0
+focus_mode = 0
+text = "PoseUpdate"
+
+[connection signal="value_changed" from="HSlider" to="." method="_on_h_slider_value_changed"]
+[connection signal="toggled" from="CheckBox" to="." method="_on_check_box_toggled"]

--- a/demo/addons/gd_cubism/example/demo_simple.tscn
+++ b/demo/addons/gd_cubism/example/demo_simple.tscn
@@ -1,24 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://dab25molfpkce"]
-
-[sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_uj6qt"]
-blend_mode = 4
-light_mode = 1
+[gd_scene format=3 uid="uid://dab25molfpkce"]
 
 [node name="simple" type="Node2D"]
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
-material = SubResource("CanvasItemMaterial_uj6qt")
+[node name="GDCubismUserModel" type="GDCubismUserModel" parent="."]
 position = Vector2(640, 360)
+scale = Vector2(0.075, 0.075)
 
-[node name="GDCubismUserModel" type="GDCubismUserModel" parent="Sprite2D"]
-disable_3d = true
-transparent_bg = true
-msaa_2d = 1
-msaa_3d = 1
-screen_space_aa = 1
-gui_disable_input = true
-render_target_update_mode = 4
+[node name="GDCubismEffectEyeBlink" type="GDCubismEffectEyeBlink" parent="GDCubismUserModel"]
 
-[node name="GDCubismEffectEyeBlink" type="GDCubismEffectEyeBlink" parent="Sprite2D/GDCubismUserModel"]
-
-[node name="GDCubismEffectBreath" type="GDCubismEffectBreath" parent="Sprite2D/GDCubismUserModel"]
+[node name="GDCubismEffectBreath" type="GDCubismEffectBreath" parent="GDCubismUserModel"]

--- a/demo/addons/gd_cubism/example/demo_transparent.gd
+++ b/demo/addons/gd_cubism/example/demo_transparent.gd
@@ -35,7 +35,7 @@ func check_cross(ary_check: Array, vtx: Vector2) -> bool:
     return (((vb.x - va.x) * (vtx.y - va.y)) - ((vb.y - va.y) * (vtx.x - va.x))) > 0
 
 
-func convex_hull(ary_vertex: Array) -> Array:
+func convex_hull(ary_vertex: Array[Vector2]) -> Array:
     ary_vertex.sort()
 
     var ary_result: Array
@@ -64,16 +64,29 @@ func convex_hull(ary_vertex: Array) -> Array:
 # ---------------------------------------------------------------------- ported
 
 
+func recalc_model_position(model: GDCubismUserModel):
+    if model.assets == "":
+        return
+
+    var canvas_info: Dictionary = model.get_canvas_info()
+
+    if canvas_info.is_empty() != true:
+        var vct_viewport_size = Vector2(get_viewport_rect().size)
+        var scale: float = vct_viewport_size.y / max(canvas_info.size_in_pixels.x, canvas_info.size_in_pixels.y)
+        model.position = vct_viewport_size / 2.0
+        model.scale = Vector2(scale, scale)
+
+
 func _ready():
 
-    if $Sprite2D/GDCubismUserModel.assets == "":
-        $Sprite2D/GDCubismUserModel.assets = DEFAULT_ASSET
+    if $GDCubismUserModel.assets == "":
+        $GDCubismUserModel.assets = DEFAULT_ASSET
 
-    $Sprite2D.position = Vector2(get_viewport_rect().size / 2)
+    recalc_model_position($GDCubismUserModel)
 
-    ary_character_expression = $Sprite2D/GDCubismUserModel.get_expressions()
+    ary_character_expression = $GDCubismUserModel.get_expressions()
 
-    var dict_motion = $Sprite2D/GDCubismUserModel.get_motions()
+    var dict_motion = $GDCubismUserModel.get_motions()
     for group in dict_motion.keys():
         for no in range(dict_motion[group]):
             ary_character_motion.append({"group": group, "no": no})
@@ -85,19 +98,22 @@ func _process(delta):
         DisplayServer.window_set_position(Vector2i(window_position))
         order_window_position = false
 
-    var dict_mesh = $Sprite2D/GDCubismUserModel.get_meshes()
+    var dict_mesh = $GDCubismUserModel.get_meshes()
     var ary: PackedVector2Array
+
     for name in CONVEX_MESH_SRC:
-        ary += dict_mesh[name].surface_get_arrays(0)[Mesh.ARRAY_VERTEX]
+        ary += dict_mesh[name].get_mesh().surface_get_arrays(0)[Mesh.ARRAY_VERTEX]
+
     var ary_polygon = convex_hull(ary)
 
     if ary_polygon.size() > 2:
         var region: PackedVector2Array
         var adjust: Vector2 = get_viewport_rect().size
-        adjust -= Vector2($Sprite2D/GDCubismUserModel.size.x, $Sprite2D/GDCubismUserModel.size.y)
-        adjust *= 0.5
+
         for v in ary_polygon:
-            region.append(v + adjust)
+            v *= $GDCubismUserModel.scale
+            v += $GDCubismUserModel.position
+            region.append(v)
 
         $Polygon2D.polygon = PackedVector2Array(region)
 
@@ -112,7 +128,7 @@ func _input(event):
 
             if event.keycode == KEY_SPACE:
                 var motion = ary_character_motion[randi_range(0, ary_character_motion.size() - 1)]
-                $Sprite2D/GDCubismUserModel.start_motion_loop(
+                $GDCubismUserModel.start_motion_loop(
                     motion.group,
                     motion.no,
                     GDCubismUserModel.PRIORITY_FORCE,
@@ -133,7 +149,7 @@ func _input(event):
             if event.keycode >= KEY_0 and event.keycode <= KEY_9:
                 var index: int = event.keycode - KEY_0
                 if index < ary_character_expression.size():
-                    $Sprite2D/GDCubismUserModel.start_expression(
+                    $GDCubismUserModel.start_expression(
                         ary_character_expression[index]
                     )
 
@@ -149,4 +165,3 @@ func _input(event):
         if mouse_button_pressed == true:
             order_window_position = true
             window_position += Vector2i(event.relative)
-

--- a/demo/addons/gd_cubism/example/demo_transparent.gd
+++ b/demo/addons/gd_cubism/example/demo_transparent.gd
@@ -78,7 +78,6 @@ func recalc_model_position(model: GDCubismUserModel):
 
 
 func _ready():
-
     if $GDCubismUserModel.assets == "":
         $GDCubismUserModel.assets = DEFAULT_ASSET
 
@@ -93,7 +92,6 @@ func _ready():
 
 
 func _process(delta):
-
     if order_window_position == true:
         DisplayServer.window_set_position(Vector2i(window_position))
         order_window_position = false
@@ -119,7 +117,6 @@ func _process(delta):
 
 
 func _input(event):
-
     if event is InputEventKey:
         if event.is_pressed() == true:
 

--- a/demo/addons/gd_cubism/example/demo_transparent.tscn
+++ b/demo/addons/gd_cubism/example/demo_transparent.tscn
@@ -1,32 +1,18 @@
-[gd_scene load_steps=4 format=3 uid="uid://7hglgm6o0ou4"]
+[gd_scene load_steps=2 format=3 uid="uid://7hglgm6o0ou4"]
 
 [ext_resource type="Script" path="res://addons/gd_cubism/example/demo_transparent.gd" id="1_v7gdn"]
-
-[sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_wfgje"]
-blend_mode = 4
-light_mode = 1
-
-[sub_resource type="ViewportTexture" id="ViewportTexture_0ckra"]
-viewport_path = NodePath("Sprite2D/GDCubismUserModel")
 
 [node name="demo_transparent" type="Node2D"]
 script = ExtResource("1_v7gdn")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
-material = SubResource("CanvasItemMaterial_wfgje")
-texture = SubResource("ViewportTexture_0ckra")
+[node name="GDCubismUserModel" type="GDCubismUserModel" parent="."]
 
-[node name="GDCubismUserModel" type="GDCubismUserModel" parent="Sprite2D"]
-disable_3d = true
-transparent_bg = true
-gui_disable_input = true
-render_target_update_mode = 4
+[node name="GDCubismEffectBreath" type="GDCubismEffectBreath" parent="GDCubismUserModel"]
 
-[node name="GDCubismEffectBreath" type="GDCubismEffectBreath" parent="Sprite2D/GDCubismUserModel"]
-
-[node name="GDCubismEffectEyeBlink" type="GDCubismEffectEyeBlink" parent="Sprite2D/GDCubismUserModel"]
+[node name="GDCubismEffectEyeBlink" type="GDCubismEffectEyeBlink" parent="GDCubismUserModel"]
 
 [node name="Polygon2D" type="Polygon2D" parent="."]
+z_index = 1024
 color = Color(1, 0, 0, 0.498039)
 
 [node name="lbl_usage" type="Label" parent="."]

--- a/demo/addons/gd_cubism/example/viewer.gd
+++ b/demo/addons/gd_cubism/example/viewer.gd
@@ -2,9 +2,6 @@
 # SPDX-FileCopyrightText: 2023 MizunagiKB <mizukb@live.jp>
 extends Control
 
-const MIX_RENDER_SIZE := 32
-const MAX_RENDER_SIZE := 2048
-const RENDER_SIZE_STEP := 256
 const ENABLE_MOTION_FINISHED := true
 
 var cubism_model: GDCubismUserModel
@@ -12,10 +9,23 @@ var ary_param: Array
 var last_motion = null
 
 
+func recalc_model_position(model: GDCubismUserModel):
+    if model.assets == "":
+        return
+
+    var canvas_info: Dictionary = model.get_canvas_info()
+
+    if canvas_info.is_empty() != true:
+        var vct_viewport_size = Vector2(get_viewport_rect().size)
+        var scale: float = vct_viewport_size.y / max(canvas_info.size_in_pixels.x, canvas_info.size_in_pixels.y)
+        model.position = vct_viewport_size / 2.0
+        model.scale = Vector2(scale, scale)
+
+
 func setup(pathname: String):
     cubism_model.assets = pathname
-    
-    var canvas_info = cubism_model.get_canvas_info()
+
+    recalc_model_position(cubism_model)
 
     var idx: int = 0
     var dict_motion = cubism_model.get_motions()
@@ -31,11 +41,6 @@ func setup(pathname: String):
         $UI/ItemListExpression.add_item(item)
 
     cubism_model.playback_process_mode = GDCubismUserModel.IDLE
-    $Sprite2D.texture = cubism_model.get_texture()
-    var mat = CanvasItemMaterial.new()
-    mat.blend_mode = CanvasItemMaterial.BLEND_MODE_PREMULT_ALPHA
-    mat.light_mode = CanvasItemMaterial.LIGHT_MODE_UNSHADED
-    $Sprite2D.material = mat
 
 
 func model3_search(dirname: String):
@@ -58,26 +63,14 @@ func model3_search(dirname: String):
 
 func _ready():
     cubism_model = GDCubismUserModel.new()
+    self.add_child(cubism_model)
+
     if ENABLE_MOTION_FINISHED == true:
         cubism_model.motion_finished.connect(_on_motion_finished)
-    $Sprite2D.add_child(cubism_model)
 
     $UI/OptModel.clear()
     $UI/OptModel.add_item("")
     model3_search("res://addons/gd_cubism/example/res/live2d")
-
-
-func _process(delta):
-    var vct_resolution = Vector2(get_window().size)        
-    var texture_height = floor(vct_resolution.y / RENDER_SIZE_STEP) * RENDER_SIZE_STEP
-    texture_height = clampi(texture_height, MIX_RENDER_SIZE, MAX_RENDER_SIZE)
-
-    cubism_model.size = Vector2.ONE * texture_height
-
-    var vct_viewport_size = Vector2(get_viewport_rect().size)
-    $Sprite2D.position = vct_viewport_size / 2
-    $Sprite2D.scale.x = vct_viewport_size.y / cubism_model.size.y
-    $Sprite2D.scale.y = $Sprite2D.scale.x
 
 
 func _on_motion_finished():

--- a/demo/addons/gd_cubism/example/viewer.tscn
+++ b/demo/addons/gd_cubism/example/viewer.tscn
@@ -58,9 +58,6 @@ offset_bottom = -57.0
 grow_horizontal = 0
 grow_vertical = 0
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2(256, 256)
-
 [connection signal="item_selected" from="UI/OptModel" to="." method="_on_opt_model_item_selected"]
 [connection signal="item_selected" from="UI/ItemListMotion" to="." method="_on_item_list_motion_item_selected"]
 [connection signal="item_selected" from="UI/ItemListExpression" to="." method="_on_item_list_expression_item_selected"]

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask.gdshader
@@ -4,12 +4,8 @@
 shader_type canvas_item;
 render_mode blend_mix, unshaded;
 
-uniform vec4 channel;
+uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
-
-void vertex() {
-    UV.y = 1.0 - UV.y;
-}
 
 void fragment() {
     COLOR = channel * texture(tex_main, UV).a;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add.gdshader
@@ -4,44 +4,23 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha, unshaded;
 
-uniform vec4 color_base;
-uniform vec4 color_screen;
-uniform vec4 color_multiply;
-uniform vec4 channel;
+uniform vec4 color_base : source_color;
+uniform vec4 color_screen : source_color;
+uniform vec4 color_multiply : source_color;
+uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform bool auto_scale;
+uniform float mask_scale;
 uniform vec2 canvas_size;
-uniform vec2 mask_size;
-uniform float ratio;
-uniform vec2 adjust_pos;
-uniform float adjust_scale;
+uniform vec2 mesh_offset;
 
+varying vec2 MASK_UV;
 
 void vertex() {
-    UV.y = 1.0 - UV.y;
-}
-
-vec2 lookup_mask_uv(vec2 screen_uv) {
-
-    if(auto_scale == false) return screen_uv;
-
-    vec2 r_uv = screen_uv - 0.5;
-    vec2 calc_pos;
-
-    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
-    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
-    calc_pos.x = calc_pos.x / canvas_size.x;
-
-    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
-    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
-    calc_pos.y = calc_pos.y / canvas_size.y;
-
-    r_uv = r_uv + calc_pos;
-    r_uv = r_uv * (1.0 / adjust_scale);
-
-    return r_uv + 0.5;
+    vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
+    vec2 mask_vtx = VERTEX - mesh_offset;
+    MASK_UV = mask_vtx / mask_size;
 }
 
 void fragment() {
@@ -53,7 +32,7 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+    vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;
 
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask.rgb = color_for_mask.rgb * mask_val;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add_inv.gdshader
@@ -4,44 +4,23 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha, unshaded;
 
-uniform vec4 color_base;
-uniform vec4 color_screen;
-uniform vec4 color_multiply;
-uniform vec4 channel;
+uniform vec4 color_base : source_color;
+uniform vec4 color_screen : source_color;
+uniform vec4 color_multiply : source_color;
+uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform bool auto_scale;
+uniform float mask_scale;
 uniform vec2 canvas_size;
-uniform vec2 mask_size;
-uniform float ratio;
-uniform vec2 adjust_pos;
-uniform float adjust_scale;
+uniform vec2 mesh_offset;
 
+varying vec2 MASK_UV;
 
 void vertex() {
-    UV.y = 1.0 - UV.y;
-}
-
-vec2 lookup_mask_uv(vec2 screen_uv) {
-
-    if(auto_scale == false) return screen_uv;
-
-    vec2 r_uv = screen_uv - 0.5;
-    vec2 calc_pos;
-
-    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
-    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
-    calc_pos.x = calc_pos.x / canvas_size.x;
-
-    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
-    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
-    calc_pos.y = calc_pos.y / canvas_size.y;
-
-    r_uv = r_uv + calc_pos;
-    r_uv = r_uv * (1.0 / adjust_scale);
-
-    return r_uv + 0.5;
+    vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
+    vec2 mask_vtx = VERTEX - mesh_offset;
+    MASK_UV = mask_vtx / mask_size;
 }
 
 void fragment() {
@@ -53,7 +32,7 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+    vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;
 
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask.rgb = color_for_mask.rgb * (1.0 - mask_val);

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix.gdshader
@@ -4,44 +4,23 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha, unshaded;
 
-uniform vec4 color_base;
-uniform vec4 color_screen;
-uniform vec4 color_multiply;
-uniform vec4 channel;
+uniform vec4 color_base : source_color;
+uniform vec4 color_screen : source_color;
+uniform vec4 color_multiply : source_color;
+uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform bool auto_scale;
+uniform float mask_scale;
 uniform vec2 canvas_size;
-uniform vec2 mask_size;
-uniform float ratio;
-uniform vec2 adjust_pos;
-uniform float adjust_scale;
+uniform vec2 mesh_offset;
 
+varying vec2 MASK_UV;
 
 void vertex() {
-    UV.y = 1.0 - UV.y;
-}
-
-vec2 lookup_mask_uv(vec2 screen_uv) {
-
-    if(auto_scale == false) return screen_uv;
-
-    vec2 r_uv = screen_uv - 0.5;
-    vec2 calc_pos;
-
-    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
-    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
-    calc_pos.x = calc_pos.x / canvas_size.x;
-
-    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
-    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
-    calc_pos.y = calc_pos.y / canvas_size.y;
-
-    r_uv = r_uv + calc_pos;
-    r_uv = r_uv * (1.0 / adjust_scale);
-
-    return r_uv + 0.5;
+    vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
+    vec2 mask_vtx = VERTEX - mesh_offset;
+    MASK_UV = mask_vtx / mask_size;
 }
 
 void fragment() {
@@ -53,7 +32,7 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+    vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;
 
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * mask_val;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix_inv.gdshader
@@ -4,44 +4,23 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha, unshaded;
 
-uniform vec4 color_base;
-uniform vec4 color_screen;
-uniform vec4 color_multiply;
-uniform vec4 channel;
+uniform vec4 color_base : source_color;
+uniform vec4 color_screen : source_color;
+uniform vec4 color_multiply : source_color;
+uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform bool auto_scale;
+uniform float mask_scale;
 uniform vec2 canvas_size;
-uniform vec2 mask_size;
-uniform float ratio;
-uniform vec2 adjust_pos;
-uniform float adjust_scale;
+uniform vec2 mesh_offset;
 
+varying vec2 MASK_UV;
 
 void vertex() {
-    UV.y = 1.0 - UV.y;
-}
-
-vec2 lookup_mask_uv(vec2 screen_uv) {
-
-    if(auto_scale == false) return screen_uv;
-
-    vec2 r_uv = screen_uv - 0.5;
-    vec2 calc_pos;
-
-    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
-    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
-    calc_pos.x = calc_pos.x / canvas_size.x;
-
-    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
-    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
-    calc_pos.y = calc_pos.y / canvas_size.y;
-
-    r_uv = r_uv + calc_pos;
-    r_uv = r_uv * (1.0 / adjust_scale);
-
-    return r_uv + 0.5;
+    vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
+    vec2 mask_vtx = VERTEX - mesh_offset;
+    MASK_UV = mask_vtx / mask_size;
 }
 
 void fragment() {
@@ -53,7 +32,7 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+    vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;
 
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * (1.0 - mask_val);

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul.gdshader
@@ -4,44 +4,23 @@
 shader_type canvas_item;
 render_mode blend_mul, unshaded;
 
-uniform vec4 color_base;
-uniform vec4 color_screen;
-uniform vec4 color_multiply;
-uniform vec4 channel;
+uniform vec4 color_base : source_color;
+uniform vec4 color_screen : source_color;
+uniform vec4 color_multiply : source_color;
+uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform bool auto_scale;
+uniform float mask_scale;
 uniform vec2 canvas_size;
-uniform vec2 mask_size;
-uniform float ratio;
-uniform vec2 adjust_pos;
-uniform float adjust_scale;
+uniform vec2 mesh_offset;
 
+varying vec2 MASK_UV;
 
 void vertex() {
-    UV.y = 1.0 - UV.y;
-}
-
-vec2 lookup_mask_uv(vec2 screen_uv) {
-
-    if(auto_scale == false) return screen_uv;
-
-    vec2 r_uv = screen_uv - 0.5;
-    vec2 calc_pos;
-
-    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
-    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
-    calc_pos.x = calc_pos.x / canvas_size.x;
-
-    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
-    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
-    calc_pos.y = calc_pos.y / canvas_size.y;
-
-    r_uv = r_uv + calc_pos;
-    r_uv = r_uv * (1.0 / adjust_scale);
-
-    return r_uv + 0.5;
+    vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
+    vec2 mask_vtx = VERTEX - mesh_offset;
+    MASK_UV = mask_vtx / mask_size;
 }
 
 void fragment() {
@@ -53,7 +32,7 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+    vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;
 
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * mask_val;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul_inv.gdshader
@@ -4,44 +4,23 @@
 shader_type canvas_item;
 render_mode blend_mul, unshaded;
 
-uniform vec4 color_base;
-uniform vec4 color_screen;
-uniform vec4 color_multiply;
-uniform vec4 channel;
+uniform vec4 color_base : source_color;
+uniform vec4 color_screen : source_color;
+uniform vec4 color_multiply : source_color;
+uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
-uniform bool auto_scale;
+uniform float mask_scale;
 uniform vec2 canvas_size;
-uniform vec2 mask_size;
-uniform float ratio;
-uniform vec2 adjust_pos;
-uniform float adjust_scale;
+uniform vec2 mesh_offset;
 
+varying vec2 MASK_UV;
 
 void vertex() {
-    UV.y = 1.0 - UV.y;
-}
-
-vec2 lookup_mask_uv(vec2 screen_uv) {
-
-    if(auto_scale == false) return screen_uv;
-
-    vec2 r_uv = screen_uv - 0.5;
-    vec2 calc_pos;
-
-    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
-    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
-    calc_pos.x = calc_pos.x / canvas_size.x;
-
-    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
-    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
-    calc_pos.y = calc_pos.y / canvas_size.y;
-
-    r_uv = r_uv + calc_pos;
-    r_uv = r_uv * (1.0 / adjust_scale);
-
-    return r_uv + 0.5;
+    vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
+    vec2 mask_vtx = VERTEX - mesh_offset;
+    MASK_UV = mask_vtx / mask_size;
 }
 
 void fragment() {
@@ -53,7 +32,7 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+    vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;
 
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * (1.0 - mask_val);

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_norm_add.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_norm_add.gdshader
@@ -4,15 +4,11 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha, unshaded;
 
-uniform vec4 color_base;
-uniform vec4 color_screen;
-uniform vec4 color_multiply;
-uniform vec4 channel;
+uniform vec4 color_base : source_color;
+uniform vec4 color_screen : source_color;
+uniform vec4 color_multiply : source_color;
+uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
-
-void vertex() {
-    UV.y = 1.0 - UV.y;
-}
 
 void fragment() {
     vec4 color_tex = texture(tex_main, UV);

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mix.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mix.gdshader
@@ -4,15 +4,11 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha, unshaded;
 
-uniform vec4 color_base;
-uniform vec4 color_screen;
-uniform vec4 color_multiply;
-uniform vec4 channel;
+uniform vec4 color_base : source_color;
+uniform vec4 color_screen : source_color;
+uniform vec4 color_multiply : source_color;
+uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
-
-void vertex() {
-    UV.y = 1.0 - UV.y;
-}
 
 void fragment() {
     vec4 color_tex = texture(tex_main, UV);

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mul.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mul.gdshader
@@ -4,15 +4,11 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha, unshaded;
 
-uniform vec4 color_base;
-uniform vec4 color_screen;
-uniform vec4 color_multiply;
-uniform vec4 channel;
+uniform vec4 color_base : source_color;
+uniform vec4 color_screen : source_color;
+uniform vec4 color_multiply : source_color;
+uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
-
-void vertex() {
-    UV.y = 1.0 - UV.y;
-}
 
 void fragment() {
     vec4 color_tex = texture(tex_main, UV);

--- a/doc_classes/GDCubismUserModel.xml
+++ b/doc_classes/GDCubismUserModel.xml
@@ -200,8 +200,15 @@
 		<member name="parameter_mode" type="int" setter="set_parameter_mode" getter="get_parameter_mode" enum="GDCubismUserModel.ParameterMode" default="0">
 			Specifies the control method for the currently held Live2D model.
 		</member>
+		<member name="physics_evaluate" type="int" setter="set_physics_evaluate" getter="get_physics_evaluate" enum="GDCubismUserModel.PhysicsEvaluate" default="true">
+			Setting this parameter to [code]false[/code] disables physical calculations.
+		</member>
 		<member name="playback_process_mode" type="int" setter="set_process_callback" getter="get_process_callback" enum="GDCubismUserModel.MotionProcessCallback" default="1">
 			Specifies the playback method for the currently held Live2D model.
+		</member>
+		<member name="pose_update" type="int" setter="set_pose_update" getter="get_pose_update" enum="GDCubismUserModel.PoseUpdate" default="true">
+			Setting this parameter to [code]false[/code] disables transparency calculations between drawing parts specified in the pose group.
+			If you want to manually handle all transparency calculations, set this parameter to [code]false[/code].
 		</member>
 		<member name="shader_add" type="Shader" setter="set_shader_add" getter="get_shader_add">
 			Specifies the [i]shader[/i] used to render the Live2D model.

--- a/doc_classes/GDCubismUserModel.xml
+++ b/doc_classes/GDCubismUserModel.xml
@@ -163,23 +163,9 @@
 		</method>
 	</methods>
 	<members>
-		<member name="adjust_position" type="Vector2" setter="set_adjust_position" getter="get_adjust_position" default="Vector2(0, 0)">
-			Changes the rendering position of the Live2D model.
-			GDCubism performs the rendering of the Live2D model within its own [SubViewport].
-			By adjusting this parameter, you can close-up a part of the Live2D model or use it when the auto_scale rendered result is not drawn well.
-		</member>
-		<member name="adjust_scale" type="float" setter="set_adjust_scale" getter="get_adjust_scale" default="1.0">
-			Changes the rendering size of the Live2D model.
-			GDCubism performs the rendering of the Live2D model within its own [SubViewport].
-			By adjusting this parameter, you can freely change the rendering size of the Live2D model.
-		</member>
 		<member name="assets" type="String" setter="set_assets" getter="get_assets" default="&quot;&quot;">
 			By specifying a file with the [code]*.model3.json[/code] extension, you can load the Live2D model. As soon as you specify a file, it will be loaded immediately.
 			if you want to switch the Live2D model, you can do so by simply specifying a new file.
-		</member>
-		<member name="auto_scale" type="bool" setter="set_auto_scale" getter="get_auto_scale" default="true">
-			[GDCubismUserModel] tries to render the Live2D model to fit within the [SubViewport] size specified for itself. Therefore, there may be results that the creator of the Live2D model did not intend.
-			By unchecking this, you can display without scaling.
 		</member>
 		<member name="load_expressions" type="bool" setter="set_load_expressions" getter="get_load_expressions" default="true">
 			If set to [code]false[/code], it will not load [i]Expressions[/i] when loading the Live2D Model.
@@ -187,15 +173,13 @@
 		<member name="load_motions" type="bool" setter="set_load_motions" getter="get_load_motions" default="true">
 			If set to [code]false[/code], it will not load [i]Motions[/i] when loading the Live2D Model.
 		</member>
-		<member name="mask_viewport_size" type="Vector2i" setter="set_mask_viewport_size" getter="get_mask_viewport_size" default="Vector2i(0, 0)">
-			Specify the resolution for the mask image required for the Live2D model.
-		If either x or y is set to 0, the same size as the Viewport set in [GDCubismUserModel] will be used.
+		<member name="mask_viewport_size" type="int" setter="set_mask_viewport_size" getter="get_mask_viewport_size" default="0">
+			Specify the maximum resolution for any individual mask required for the Live2D model.
+		If set to 0, size of the mask will be relative to the source pixel resolution of the model's canvas.
+		Mask resolution is also dynamically resized relative to the model's scale within its viewport.
 
-		Reducing the resolution can help conserve GPU memory.
-		However, if the size is reduced to less than approximately 512x512, there may be issues with rendering quality depending on where the mask is applied.
-		Ensure that the aspect ratio of this image matches the aspect ratio of the Viewport in [GDCubismUserModel]. For example, if it is _1024x512_, then values like _512x256_ or _128x64_ are appropriate.
-
-		Since GDCubism assumes the same aspect ratio as the Viewport for rendering, using an incorrect ratio may result in undesirable outcomes.
+		Reducing the resolution can help conserve GPU memory, however reducing resolution too far can cause visual issues where masks are applied.
+		For many, it's best to leave this at default and rely solely on the automatic scaling.
 		</member>
 		<member name="parameter_mode" type="int" setter="set_parameter_mode" getter="get_parameter_mode" enum="GDCubismUserModel.ParameterMode" default="0">
 			Specifies the control method for the currently held Live2D model.

--- a/docs-site/antora-playbook.yml
+++ b/docs-site/antora-playbook.yml
@@ -5,7 +5,7 @@ site:
 content:
   sources:
     - url: https://github.com/MizunagiKB/gd_cubism.git
-      branches: [0.6, 0.7]
+      branches: [0.6, 0.7, 0.8]
       start_path: docs-src
 ui:
   bundle:

--- a/docs-src/antora.yml
+++ b/docs-src/antora.yml
@@ -1,5 +1,5 @@
 name: gd_cubism
-version: "0.7"
+version: "0.8"
 title: GDCubism
 start_page: ja/index.adoc
 nav:

--- a/docs-src/modules/ROOT/examples/2d_cubism_mask_add.gdshader
+++ b/docs-src/modules/ROOT/examples/2d_cubism_mask_add.gdshader
@@ -11,8 +11,37 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
+
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
@@ -24,7 +53,8 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, SCREEN_UV) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask.rgb = color_for_mask.rgb * mask_val;
     COLOR = vec4(color_for_mask.rgb, 0.0);

--- a/docs-src/modules/ROOT/examples/2d_cubism_mask_add_inv.gdshader
+++ b/docs-src/modules/ROOT/examples/2d_cubism_mask_add_inv.gdshader
@@ -11,20 +11,50 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
+
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
     vec4 color_tex = texture(tex_main, UV);
     color_tex.rgb = color_tex.rgb * color_multiply.rgb;
 
-    // premul alpha    
+    // premul alpha
     color_tex.rgb = color_tex.rgb + color_screen.rgb - (color_tex.rgb * color_screen.rgb);
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, SCREEN_UV) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask.rgb = color_for_mask.rgb * (1.0 - mask_val);
     COLOR = vec4(color_for_mask.rgb, 0.0);

--- a/docs-src/modules/ROOT/examples/2d_cubism_mask_mix.gdshader
+++ b/docs-src/modules/ROOT/examples/2d_cubism_mask_mix.gdshader
@@ -11,8 +11,37 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
+
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
@@ -24,7 +53,8 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, SCREEN_UV) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * mask_val;
     COLOR = color_for_mask;

--- a/docs-src/modules/ROOT/examples/2d_cubism_mask_mix_inv.gdshader
+++ b/docs-src/modules/ROOT/examples/2d_cubism_mask_mix_inv.gdshader
@@ -11,20 +11,50 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
+
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
     vec4 color_tex = texture(tex_main, UV);
     color_tex.rgb = color_tex.rgb * color_multiply.rgb;
-    
-    // premul alpha    
+
+    // premul alpha
     color_tex.rgb = color_tex.rgb + color_screen.rgb - (color_tex.rgb * color_screen.rgb);
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, SCREEN_UV) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * (1.0 - mask_val);
     COLOR = color_for_mask;

--- a/docs-src/modules/ROOT/examples/2d_cubism_mask_mul.gdshader
+++ b/docs-src/modules/ROOT/examples/2d_cubism_mask_mul.gdshader
@@ -11,8 +11,37 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
+
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
@@ -24,7 +53,8 @@ void fragment() {
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, SCREEN_UV) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * mask_val;
     COLOR = vec4(

--- a/docs-src/modules/ROOT/examples/2d_cubism_mask_mul_inv.gdshader
+++ b/docs-src/modules/ROOT/examples/2d_cubism_mask_mul_inv.gdshader
@@ -11,20 +11,50 @@ uniform vec4 channel;
 uniform sampler2D tex_main : filter_linear_mipmap;
 uniform sampler2D tex_mask : filter_linear_mipmap;
 
+uniform bool auto_scale;
+uniform vec2 canvas_size;
+uniform vec2 mask_size;
+uniform float ratio;
+uniform vec2 adjust_pos;
+uniform float adjust_scale;
+
+
 void vertex() {
     UV.y = 1.0 - UV.y;
+}
+
+vec2 lookup_mask_uv(vec2 screen_uv) {
+
+    if(auto_scale == false) return screen_uv;
+
+    vec2 r_uv = screen_uv - 0.5;
+    vec2 calc_pos;
+
+    calc_pos.x = (canvas_size.x * adjust_scale) - canvas_size.x;
+    calc_pos.x = calc_pos.x * (adjust_pos.x / canvas_size.x);
+    calc_pos.x = calc_pos.x / canvas_size.x;
+
+    calc_pos.y = (canvas_size.y * adjust_scale) - canvas_size.y;
+    calc_pos.y = calc_pos.y * (adjust_pos.y / canvas_size.y);
+    calc_pos.y = calc_pos.y / canvas_size.y;
+
+    r_uv = r_uv + calc_pos;
+    r_uv = r_uv * (1.0 / adjust_scale);
+
+    return r_uv + 0.5;
 }
 
 void fragment() {
     vec4 color_tex = texture(tex_main, UV);
     color_tex.rgb = color_tex.rgb * color_multiply.rgb;
-    
-    // premul alpha    
+
+    // premul alpha
     color_tex.rgb = color_tex.rgb + color_screen.rgb - (color_tex.rgb * color_screen.rgb);
     vec4 color_for_mask = color_tex * color_base;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
-    vec4 clip_mask = texture(tex_mask, SCREEN_UV) * channel;
+    vec4 clip_mask = texture(tex_mask, lookup_mask_uv(SCREEN_UV)) * channel;
+
     float mask_val = clip_mask.r + clip_mask.g + clip_mask.b + clip_mask.a;
     color_for_mask = color_for_mask * (1.0 - mask_val);
     COLOR = vec4(

--- a/docs-src/modules/ROOT/pages/en/api/gd_cubism_user_model.adoc
+++ b/docs-src/modules/ROOT/pages/en/api/gd_cubism_user_model.adoc
@@ -35,7 +35,9 @@ This is a _SubViewport_ subclass for loading the Live2D model, generating the _T
 >|bool <|<<id-property-load_motions,load_motions>> |[default: true]
 >|Vector2i <|<<id-property-mask_viewport_size,mask_viewport_size>> |[default: Vector2i(0, 0)]
 >|ParameterMode <|<<id-property-parameter_mode,parameter_mode>> |[default: 0]
+>|bool <|<<physics_evaluate>> |[default: true]
 >|MotionProcessCallback <|<<id-property-playback_process_mode,playback_process_mode>> |[default: 1]
+>|bool <|<<pose_update>> |[default: true]
 >|Shader <|<<id-property-shader_add,shader_add>> |
 >|Shader <|<<id-property-shader_mask,shader_mask>> |
 >|Shader <|<<id-property-shader_mask_add,shader_mask_add>> |
@@ -209,9 +211,21 @@ Since GDCubism assumes the same aspect ratio as the Viewport for rendering, usin
 ParameterMode parameter_mode [default: 0]::
 Specifies the control method for the currently held Live2D model.
 
+
+[[id-property-physics_evaluate]]
+bool physics_evaluate [default: true]::
+Setting this parameter to `false` disables physical calculations.
+
+
 [[id-property-playback_process_mode]]
 MotionProcessCallback playback_process_mode [default: 1]::
 Specifies the playback method for the currently held Live2D model.
+
+
+[[id-property-pose_update]]
+bool pose_update [default: true]::
+Setting this parameter to `false` disables transparency calculations between drawing parts specified in the pose group. +
+If you want to manually handle all transparency calculations, set this parameter to `false`.
 
 
 [[id-property-shader_add]]

--- a/docs-src/modules/ROOT/pages/ja/api/gd_cubism_user_model.adoc
+++ b/docs-src/modules/ROOT/pages/ja/api/gd_cubism_user_model.adoc
@@ -22,6 +22,7 @@ endif::env-github,env-vscode[]
 Live2Dモデルを読み込み、表示に必要な _Texture_ を生成したり操作を行うための _SubVieport_ 継承クラスです。
 
 
+
 == Properties
 
 [cols="3",frame=none,grid=none]
@@ -32,8 +33,11 @@ Live2Dモデルを読み込み、表示に必要な _Texture_ を生成したり
 >|bool <|<<id-property-auto_scale,auto_scale>> |[default: true]
 >|bool <|<<id-property-load_expressions,load_expressions>> |[default: true]
 >|bool <|<<id-property-load_motions,load_motions>> |[default: true]
+>|Vector2i <|<<id-property-mask_viewport_size>> |[default: Vector2i(0, 0)]
 >|ParameterMode <|<<id-property-parameter_mode,parameter_mode>> |[default: 0]
+>|bool <|<<physics_evaluate>> |[default: true]
 >|MotionProcessCallback <|<<id-property-playback_process_mode,playback_process_mode>> |[default: 1]
+>|bool <|<<pose_update>> |[default: true]
 >|Shader <|<<id-property-shader_add,shader_add>> |
 >|Shader <|<<id-property-shader_mask,shader_mask>> |
 >|Shader <|<<id-property-shader_mask_add,shader_mask_add>> |
@@ -205,9 +209,20 @@ ParameterMode parameter_mode [default: 0]::
 現在保持しているLive2Dモデルのコントロール方法を指定します。
 
 
+[[id-property-physics_evaluate]]
+bool physics_evaluate [default: true]::
+_false_ にすると、物理計算を行わなくなります。
+
+
 [[id-property-playback_process_mode]]
 MotionProcessCallback playback_process_mode [default: 1]::
 現在保持しているLive2Dモデルの再生方法を指定します。
+
+
+[[id-property-pose_update]]
+bool pose_update [default: true]::
+_false_ にすると、ポーズグループに指定された描画パーツ同士で透明度の計算を行わなくなります。 +
+全ての透明度計算を手動で行いたい場合は _false_ にしてください。
 
 
 [[id-property-shader_add]]

--- a/src/gd_cubism_effect_hit_area.hpp
+++ b/src/gd_cubism_effect_hit_area.hpp
@@ -121,8 +121,9 @@ public:
         const Dictionary dict_mesh = model->get_meshes();
         if(dict_mesh.is_empty() == true) return Dictionary();
 
-        Ref<ArrayMesh> ref_ary_mesh = dict_mesh[id];
-        if(ref_ary_mesh.is_null() == true) return Dictionary();
+        MeshInstance2D* p_mesh_inst = cast_to<MeshInstance2D>(dict_mesh[id]);
+        Ref<ArrayMesh> ref_ary_mesh =  static_cast<ArrayMesh*>(p_mesh_inst->get_mesh().ptr());
+        if(ref_ary_mesh.is_valid() != true) return Dictionary();
         if(ref_ary_mesh->surface_get_array_index_len(0) < 3) return Dictionary();
 
         Dictionary dict_result;
@@ -176,7 +177,9 @@ public:
             const String id = static_cast<Dictionary>(ary[i]).get("id", String());
             if(dict_mesh.has(id) != true) continue;
 
-            Ref<ArrayMesh> ref_ary_mesh = dict_mesh[id];
+            MeshInstance2D* p_mesh_inst = cast_to<MeshInstance2D>(dict_mesh[id]);
+            Ref<ArrayMesh> ref_ary_mesh =  static_cast<ArrayMesh*>(p_mesh_inst->get_mesh().ptr());
+            if(ref_ary_mesh.is_valid() != true) continue;
             if(ref_ary_mesh->surface_get_array_index_len(0) < 3) continue;
 
             Rect2 check_rect = this->build_rect2(ref_ary_mesh);

--- a/src/gd_cubism_effect_target_point.hpp
+++ b/src/gd_cubism_effect_target_point.hpp
@@ -112,7 +112,7 @@ private:
 
     Csm::csmMap<E_PARAM, Csm::csmInt32> _map_param_idx;
 
-    bool _need_update = false;
+    bool _need_update = true;
 
 private:
     Csm::csmInt32 find_idx(Csm::CubismModel* _model, const Csm::csmString name) const {

--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -6,7 +6,6 @@
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/ref.hpp>
 #include <godot_cpp/classes/sprite2d.hpp>
-#include <godot_cpp/classes/viewport_texture.hpp>
 #include <godot_cpp/classes/window.hpp>
 
 #include <CubismFramework.hpp>
@@ -36,10 +35,7 @@ GDCubismUserModel::GDCubismUserModel()
     , enable_load_expressions(true)
     , enable_load_motions(true)
     , speed_scale(1.0)
-    , auto_scale(true)
-    , adjust_scale(1.0)
-    , adjust_pos(0.0, 0.0)
-    , mask_viewport_size(0, 0)
+    , mask_viewport_size(0)
     , parameter_mode(ParameterMode::FULL_PARAMETER)
     , physics_evaluate(true)
     , pose_update(true)
@@ -99,21 +95,9 @@ void GDCubismUserModel::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_speed_scale"), &GDCubismUserModel::get_speed_scale);
     ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "0.0,256.0,0.1"), "set_speed_scale", "get_speed_scale");
 
-    ClassDB::bind_method(D_METHOD("set_auto_scale", "value"), &GDCubismUserModel::set_auto_scale);
-    ClassDB::bind_method(D_METHOD("get_auto_scale"), &GDCubismUserModel::get_auto_scale);
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_scale"), "set_auto_scale", "get_auto_scale");
-
-    ClassDB::bind_method(D_METHOD("set_adjust_scale", "value"), &GDCubismUserModel::set_adjust_scale);
-    ClassDB::bind_method(D_METHOD("get_adjust_scale"), &GDCubismUserModel::get_adjust_scale);
-    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjust_scale", PROPERTY_HINT_RANGE, "0.01,16.0,0.01"), "set_adjust_scale", "get_adjust_scale");
-
-    ClassDB::bind_method(D_METHOD("set_adjust_position", "value"), &GDCubismUserModel::set_adjust_position);
-    ClassDB::bind_method(D_METHOD("get_adjust_position"), &GDCubismUserModel::get_adjust_position);
-    ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "adjust_position"), "set_adjust_position", "get_adjust_position");
-
     ClassDB::bind_method(D_METHOD("set_mask_viewport_size", "value"), &GDCubismUserModel::set_mask_viewport_size);
     ClassDB::bind_method(D_METHOD("get_mask_viewport_size"), &GDCubismUserModel::get_mask_viewport_size);
-    ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "mask_viewport_size"), "set_mask_viewport_size", "get_mask_viewport_size");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "mask_viewport_size", PROPERTY_HINT_RANGE, "0, 4096"), "set_mask_viewport_size", "get_mask_viewport_size");
 
     ClassDB::bind_method(D_METHOD("set_shader_add"), &GDCubismUserModel::set_shader_add);
     ClassDB::bind_method(D_METHOD("get_shader_add"), &GDCubismUserModel::get_shader_add);
@@ -311,16 +295,6 @@ void GDCubismUserModel::set_speed_scale(const float speed) {
 
 float GDCubismUserModel::get_speed_scale() const {
     return this->speed_scale;
-}
-
-
-void GDCubismUserModel::set_auto_scale(const bool value) {
-    this->auto_scale = value;
-}
-
-
-bool GDCubismUserModel::get_auto_scale() const {
-    return this->auto_scale;
 }
 
 
@@ -843,19 +817,6 @@ void GDCubismUserModel::load_model(const String assets) {
 }
 
 void GDCubismUserModel::_ready() {
-    // Setup SubViewport
-    this->set_disable_3d(SUBVIEWPORT_DISABLE_3D_FLAG);
-    this->set_clear_mode(SubViewport::ClearMode::CLEAR_MODE_ALWAYS);
-    // set_update_mode must be specified
-    this->set_update_mode(SubViewport::UpdateMode::UPDATE_ALWAYS);
-    this->set_disable_input(true);
-    // Memory leak when set_use_own_world_3d is true
-    // https://github.com/godotengine/godot/issues/81476
-    this->set_use_own_world_3d(SUBVIEWPORT_USE_OWN_WORLD_3D_FLAG);
-    // Memory leak when set_transparent_background is true(* every time & window minimize)
-    // https://github.com/godotengine/godot/issues/89651
-    this->set_transparent_background(true);
-
     if (!this->assets.is_empty()) {
         this->load_model(this->assets);
     }

--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -41,6 +41,8 @@ GDCubismUserModel::GDCubismUserModel()
     , adjust_pos(0.0, 0.0)
     , mask_viewport_size(0, 0)
     , parameter_mode(ParameterMode::FULL_PARAMETER)
+    , physics_evaluate(true)
+    , pose_update(true)
     , playback_process_mode(MotionProcessCallback::IDLE)
     , anim_loop(DEFAULT_PROP_ANIM_LOOP)
     , anim_loop_fade_in(DEFAULT_PROP_ANIM_LOOP_FADE_IN)
@@ -80,6 +82,14 @@ void GDCubismUserModel::_bind_methods() {
     ClassDB::bind_method(D_METHOD("set_parameter_mode", "value"), &GDCubismUserModel::set_parameter_mode);
     ClassDB::bind_method(D_METHOD("get_parameter_mode"), &GDCubismUserModel::get_parameter_mode);
     ADD_PROPERTY(PropertyInfo(Variant::INT, "parameter_mode", PROPERTY_HINT_ENUM, "FullParameter,NoneParameter"), "set_parameter_mode", "get_parameter_mode");
+
+    ClassDB::bind_method(D_METHOD("set_physics_evaluate", "enable"), &GDCubismUserModel::set_physics_evaluate);
+    ClassDB::bind_method(D_METHOD("get_physics_evaluate"), &GDCubismUserModel::get_physics_evaluate);
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_evaluate"), "set_physics_evaluate", "get_physics_evaluate");
+
+    ClassDB::bind_method(D_METHOD("set_pose_update", "enable"), &GDCubismUserModel::set_pose_update);
+    ClassDB::bind_method(D_METHOD("get_pose_update"), &GDCubismUserModel::get_pose_update);
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pose_update"), "set_pose_update", "get_pose_update");
 
     ClassDB::bind_method(D_METHOD("set_process_callback", "value"), &GDCubismUserModel::set_process_callback);
     ClassDB::bind_method(D_METHOD("get_process_callback"), &GDCubismUserModel::get_process_callback);

--- a/src/gd_cubism_user_model.hpp
+++ b/src/gd_cubism_user_model.hpp
@@ -10,7 +10,7 @@
 #include <godot_cpp/classes/canvas_group.hpp>
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/shader.hpp>
-#include <godot_cpp/classes/sub_viewport.hpp>
+#include <godot_cpp/classes/node2d.hpp>
 
 #include <CubismFramework.hpp>
 #include <Math/CubismVector2.hpp>
@@ -68,8 +68,8 @@ public:
 };
 
 
-class GDCubismUserModel : public SubViewport {
-    GDCLASS(GDCubismUserModel, SubViewport);
+class GDCubismUserModel : public Node2D {
+    GDCLASS(GDCubismUserModel, Node2D);
 
 public:
     GDCubismUserModel();
@@ -109,11 +109,8 @@ public:
     bool enable_load_motions;
 
     float speed_scale;
-    bool auto_scale;
-    float adjust_scale;
-    Vector2 adjust_pos;
-    Vector2i mask_viewport_size;
-
+    int32_t mask_viewport_size;
+    
     ParameterMode parameter_mode;
     bool physics_evaluate;
     bool pose_update;
@@ -172,18 +169,6 @@ public:
 
     void set_speed_scale(const float speed);
     float get_speed_scale() const;
-
-    void set_auto_scale(const bool value);
-    bool get_auto_scale() const;
-
-    void set_adjust_scale(const float scale) { this->adjust_scale = scale; }
-    float get_adjust_scale() const { return this->adjust_scale; }
-
-    void set_adjust_position(const Vector2 pos) { this->adjust_pos = pos; }
-    Vector2 get_adjust_position() const { return this->adjust_pos; }
-
-    void set_mask_viewport_size(const Vector2i size) { this->mask_viewport_size = size; }
-    Vector2i get_mask_viewport_size() const { return this->mask_viewport_size; }
 
     Dictionary get_motions() const;
     Ref<GDCubismMotionQueueEntryHandle> start_motion(const String str_group, const int32_t no, const Priority priority);
@@ -251,6 +236,9 @@ public:
     bool _property_can_revert(const StringName &p_name) const;
     bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
     void _get_property_list(List<godot::PropertyInfo> *p_list);
+
+    void set_mask_viewport_size(const int32_t size) { this->mask_viewport_size = size; }
+    int32_t get_mask_viewport_size() const { return this->mask_viewport_size; }
 
     void _ready() override;
     void _enter_tree() override;

--- a/src/gd_cubism_user_model.hpp
+++ b/src/gd_cubism_user_model.hpp
@@ -115,6 +115,8 @@ public:
     Vector2i mask_viewport_size;
 
     ParameterMode parameter_mode;
+    bool physics_evaluate;
+    bool pose_update;
     MotionProcessCallback playback_process_mode;
 
     Array ary_shader;
@@ -158,6 +160,12 @@ public:
 
     void set_parameter_mode(const ParameterMode value);
     GDCubismUserModel::ParameterMode get_parameter_mode() const;
+
+    void set_physics_evaluate(const bool enable) { this->physics_evaluate = enable; }
+    bool get_physics_evaluate() const { return this->physics_evaluate; }
+
+    void set_pose_update(const bool enable) { this->pose_update = enable; }
+    bool get_pose_update() const { return this->pose_update; }
 
     void set_process_callback(const MotionProcessCallback value);
     GDCubismUserModel::MotionProcessCallback get_process_callback() const;

--- a/src/private/internal_cubism_renderer_2d.cpp
+++ b/src/private/internal_cubism_renderer_2d.cpp
@@ -6,6 +6,7 @@
 
 #include <godot_cpp/classes/shader_material.hpp>
 #include <godot_cpp/classes/viewport_texture.hpp>
+#include <godot_cpp/classes/rendering_server.hpp>
 
 #include <CubismFramework.hpp>
 #include <Model/CubismModel.hpp>
@@ -25,9 +26,9 @@ using namespace godot;
 // -------------------------------------------------------------------- enum(s)
 // ------------------------------------------------------------------- const(s)
 // ------------------------------------------------------------------ static(s)
-PackedInt32Array make_PackedArrayInt32(const csmUint16 *ptr, const int32_t &size);
-PackedVector2Array make_PackedArrayVector2(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size);
-PackedVector2Array make_PackedArrayVector3(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size, const Csm::csmFloat32 &ppunit, const Vector2 &vct_adjust);
+PackedInt32Array make_Indices(const csmUint16 *ptr, const int32_t &size);
+PackedVector2Array make_UVs(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size);
+PackedVector2Array make_Vertices(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size, const Csm::csmFloat32 &ppunit, const Vector2 &vct_adjust);
 const Vector4 make_vector4(const Live2D::Cubism::Core::csmVector4 &src_vec4);
 
 // ----------------------------------------------------------- class:forward(s)
@@ -57,35 +58,9 @@ void InternalCubismRenderer2D::make_ArrayMesh_prepare(
     const Vector2 vct_origin = this->get_origin(model);
     const float ppunit = this->get_ppunit(model);
 
-    res.vct_canvas_size = res._owner_viewport->get_size();
-
-    if (res._owner_viewport->mask_viewport_size.x > 0 && res._owner_viewport->mask_viewport_size.y > 0)
-    {
-        res.vct_mask_size = res._owner_viewport->mask_viewport_size;
-    }
-    else
-    {
-        res.vct_mask_size = res._owner_viewport->get_size();
-    }
-
-    res.CALCULATED_ORIGIN_C = (Vector2(res.vct_canvas_size) * vct_origin) / vct_size;
-    res.CALCULATED_ORIGIN_M = (Vector2(res.vct_mask_size) * vct_origin) / vct_size;
-    res.RATIO = float(res.vct_mask_size.x) / float(res.vct_canvas_size.x);
-
-    if (res._owner_viewport->auto_scale == true)
-    {
-        float fdstC = godot::MIN(res.vct_canvas_size.x, res.vct_canvas_size.y);
-        float fdstM = godot::MIN(res.vct_mask_size.x, res.vct_mask_size.y);
-        float fsrc = godot::MAX(vct_size.x, vct_size.y);
-
-        res.CALCULATED_PPUNIT_C = (fdstC * ppunit) / fsrc;
-        res.CALCULATED_PPUNIT_M = (fdstM * ppunit) / fsrc;
-    }
-    else
-    {
-        res.CALCULATED_PPUNIT_C = ppunit;
-        res.CALCULATED_PPUNIT_M = ppunit * res.RATIO;
-    }
+    res.vct_canvas_size = vct_size;
+    res.CALCULATED_ORIGIN_C = vct_origin;
+    res.CALCULATED_PPUNIT_C = ppunit;
 }
 
 void InternalCubismRenderer2D::update_mesh(
@@ -93,54 +68,37 @@ void InternalCubismRenderer2D::update_mesh(
     const Csm::csmInt32 index,
     const bool maskmode,
     const InternalCubismRendererResource &res,
-    const Ref<ArrayMesh> ary_mesh
+    const MeshInstance2D *node
 ) const
 {
-    const Vector2 adjust_pos = res.adjust_pos;
-
+    Ref<ArrayMesh> ary_mesh = node->get_mesh();
     ary_mesh->clear_surfaces();
 
     Array ary;
 
     ary.resize(Mesh::ARRAY_MAX);
 
-    if (maskmode == true)
-    {
-        if (res._owner_viewport->auto_scale == true)
-        {
-            ary[Mesh::ARRAY_VERTEX] = make_PackedArrayVector3(
-                model->GetDrawableVertexPositions(index),
-                model->GetDrawableVertexCount(index),
-                res.CALCULATED_PPUNIT_M,
-                res.CALCULATED_ORIGIN_M + adjust_pos * res.RATIO);
-        }
-        else
-        {
-            ary[Mesh::ARRAY_VERTEX] = make_PackedArrayVector3(
-                model->GetDrawableVertexPositions(index),
-                model->GetDrawableVertexCount(index),
-                res.CALCULATED_PPUNIT_M * res.adjust_scale,
-                res.CALCULATED_ORIGIN_M + adjust_pos * res.RATIO);
-        }
-    }
-    else
-    {
-        ary[Mesh::ARRAY_VERTEX] = make_PackedArrayVector3(
-            model->GetDrawableVertexPositions(index),
-            model->GetDrawableVertexCount(index),
-            res.CALCULATED_PPUNIT_C * res.adjust_scale,
-            res.CALCULATED_ORIGIN_C + res.adjust_pos);
-    }
+    ary[Mesh::ARRAY_VERTEX] = make_Vertices(
+        model->GetDrawableVertexPositions(index),
+        model->GetDrawableVertexCount(index),
+        res.CALCULATED_PPUNIT_C,
+        res.CALCULATED_ORIGIN_C);
 
-    ary[Mesh::ARRAY_TEX_UV] = make_PackedArrayVector2(
+    ary[Mesh::ARRAY_TEX_UV] = make_UVs(
         model->GetDrawableVertexUvs(index),
         model->GetDrawableVertexCount(index));
 
-    ary[Mesh::ARRAY_INDEX] = make_PackedArrayInt32(
+    ary[Mesh::ARRAY_INDEX] = make_Indices(
         model->GetDrawableVertexIndices(index),
         model->GetDrawableVertexIndexCount(index));
 
     ary_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, ary);
+
+    AABB bounds = ary_mesh->get_aabb();
+    RenderingServer::get_singleton()->canvas_item_set_custom_rect(
+        node->get_canvas_item(), true,
+        Rect2(bounds.position.x, bounds.position.y, bounds.size.x, bounds.size.y)
+    );
 }
 
 Vector2 InternalCubismRenderer2D::get_size(const Csm::CubismModel *model) const
@@ -176,7 +134,7 @@ float InternalCubismRenderer2D::get_ppunit(const Csm::CubismModel *model) const
     return ppunit;
 }
 
-void InternalCubismRenderer2D::update(InternalCubismRendererResource &res)
+void InternalCubismRenderer2D::update(InternalCubismRendererResource &res, int32_t mask_viewport_size)
 {
     const CubismModel *model = this->GetModel();
     const Csm::csmInt32 *renderOrder = model->GetDrawableRenderOrders();
@@ -199,42 +157,89 @@ void InternalCubismRenderer2D::update(InternalCubismRendererResource &res)
         if (node == nullptr) {
             continue;
         }
-        const bool visible = model->GetDrawableDynamicFlagIsVisible(index);
+        const bool visible = model->GetDrawableDynamicFlagIsVisible(index) && model->GetDrawableOpacity(index) > 0.0f;
         node->set_visible(visible);
-        if (!visible) {
+        Ref<ShaderMaterial> mat = node->get_material();
+        
+        if (visible) {
+            this->update_mesh(model, index, false, res, node);
+            this->update_material(model, index, mat);
+            node->set_z_index(renderOrder[index]);
+        }
+        
+        // adjust real bounds to prevent the mesh being culled
+        AABB bounds = node->get_mesh()->get_aabb();
+        Rect2 canvas_bounds = Rect2(bounds.position.x, bounds.position.y, bounds.size.x, bounds.size.y);
+        RenderingServer::get_singleton()->canvas_item_set_custom_rect(
+            node->get_canvas_item(), true,
+            canvas_bounds
+        );
+
+        if (!node->has_meta("viewport")) continue;
+
+        SubViewport *viewport = Object::cast_to<SubViewport>(node->get_meta("viewport"));
+        
+        // detect if the canvas item is going to be culled
+        // only cull viewports when not looking at the model in the editor
+        Rect2 bounds_in_viewport = node->get_global_transform_with_canvas().xform(canvas_bounds);
+        const bool is_culled = 
+            !Engine::get_singleton()->is_editor_hint() &&
+            !(
+                node->get_viewport_rect().intersects(bounds_in_viewport) 
+                || node->get_viewport_rect().encloses(bounds_in_viewport)
+            );
+
+        if (!visible || is_culled){
+            viewport->set_size(Vector2i(2,2));
             continue;
         }
-        Ref<ShaderMaterial> mat = node->get_material();
 
-        this->update_mesh(model, index, false, res, node->get_mesh());
-        this->update_material(model, index, mat);
-        node->set_z_index(renderOrder[index]);
-
-        if (model->GetDrawableMaskCounts()[index] > 0) {
-            SubViewport *viewport = Object::cast_to<SubViewport>(node->get_meta("viewport"));
-            viewport->set_size(res.vct_mask_size);
-            mat->set_shader_parameter("auto_scale", res._owner_viewport->auto_scale);
-            mat->set_shader_parameter("canvas_size", Vector2(res.vct_canvas_size));
-            mat->set_shader_parameter("mask_size", Vector2(res.vct_mask_size));
-            mat->set_shader_parameter("ratio", res.RATIO);
-            mat->set_shader_parameter("adjust_scale", res.adjust_scale);
-            mat->set_shader_parameter("adjust_pos", res.adjust_pos);
-
-            const Array masks = res.dict_mask[node_name];
-            
-            for (Csm::csmInt32 m_index = 0; m_index < model->GetDrawableMaskCounts()[index]; m_index++)
-            {
-                Csm::csmInt32 j = model->GetDrawableMasks()[index][m_index];
-
-                if (model->GetDrawableVertexCount(j) == 0)
-                    continue;
-                if (model->GetDrawableVertexIndexCount(j) == 0)
-                    continue;
-        
-                MeshInstance2D *node = Object::cast_to<MeshInstance2D>(masks[m_index]);
-                this->update_mesh(model, j, true, res, node->get_mesh());
-                node->set_z_index(renderOrder[index]);
+        // optimize mask viewport size by scaling it relative to the viewport transform
+        // maximum resolution should be equal to raw size from mesh dimensions, or the upper bound defined on the model
+        Vector2 mask_size = Math::min(bounds_in_viewport.size, canvas_bounds.size);
+        Vector2 vp_scale = Vector2(mask_size) / Vector2(canvas_bounds.size);
+        double scalar = 1.0;
+        if (mask_viewport_size > 0) {
+            if (mask_size.x > mask_viewport_size || mask_size.y > mask_viewport_size) {
+                scalar = mask_viewport_size / Math::max(mask_size.x, mask_size.y);
+                Vector2 ratio = Vector2(
+                    Math::min(1.0f, mask_size.x / mask_size.y),
+                    Math::min(1.0f, mask_size.y / mask_size.x)
+                );
+                mask_size = Vector2(mask_viewport_size, mask_viewport_size) * ratio;
             }
+        }
+
+        Vector2 viewport_offset = Vector2(bounds.position.x, bounds.position.y);
+        Transform2D transform = Transform2D(0, -viewport_offset);
+        transform.scale(Size2(scalar, scalar) * vp_scale);
+        viewport->set_size(mask_size);
+        viewport->set_canvas_transform(transform);
+
+        mat->set_shader_parameter("tex_mask", viewport->get_texture());
+        mat->set_shader_parameter("mask_scale", scalar * vp_scale.x);
+        mat->set_shader_parameter("mesh_offset", viewport_offset);
+
+        const Array masks = res.dict_mask[node_name];
+        
+        for (Csm::csmInt32 m_index = 0; m_index < model->GetDrawableMaskCounts()[index]; m_index++)
+        {
+            Csm::csmInt32 j = model->GetDrawableMasks()[index][m_index];
+
+            if (model->GetDrawableVertexCount(j) == 0)
+                continue;
+            if (model->GetDrawableVertexIndexCount(j) == 0)
+                continue;
+    
+            MeshInstance2D *node = Object::cast_to<MeshInstance2D>(masks[m_index]);
+            node->set_visible(visible);
+
+            if (!visible) {
+                continue;
+            }
+
+            this->update_mesh(model, j, true, res, node);
+            node->set_z_index(renderOrder[index]);
         }
     }
 }
@@ -262,7 +267,7 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res, 
         MeshInstance2D* node = res.request_mesh_instance();
         ShaderMaterial* mat = res.request_shader_material(model, index);
         node->set_material(mat);        
-        this->update_mesh(model, index, false, res, node->get_mesh());
+        this->update_mesh(model, index, false, res, node);
         node->set_name(node_name);
 
         // build mask
@@ -273,8 +278,6 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res, 
             
             SubViewport* viewport = memnew(SubViewport);
             {
-                viewport->set_size(res.vct_mask_size);
-
                 viewport->set_disable_3d(SUBVIEWPORT_DISABLE_3D_FLAG);
                 viewport->set_clear_mode(SubViewport::ClearMode::CLEAR_MODE_ALWAYS);
                 // set_update_mode must be specified
@@ -301,7 +304,7 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res, 
 
                     MeshInstance2D *node = res.request_mesh_instance();
                     ShaderMaterial *mat = res.request_mask_material();
-                    this->update_mesh(model, j, true, res, node->get_mesh());
+                    this->update_mesh(model, j, true, res, node);
 
                     node->set_name(mask_name);
                     node->set_material(mat);
@@ -321,18 +324,20 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res, 
             target_node->add_child(viewport);
             res.managed_nodes.append(viewport);
 
-            mat->set_shader_parameter("tex_mask", viewport->get_texture());
-            mat->set_shader_parameter("auto_scale", res._owner_viewport->auto_scale);
-            mat->set_shader_parameter("canvas_size", Vector2(res.vct_canvas_size));
-            mat->set_shader_parameter("mask_size", Vector2(res.vct_mask_size));
-            mat->set_shader_parameter("ratio", res.RATIO);
-            mat->set_shader_parameter("adjust_scale", res.adjust_scale);
-            mat->set_shader_parameter("adjust_pos", res.adjust_pos);
-
             viewport->set_name(node_name + "__mask");
             res.dict_mask[node_name] = masks;
 
             node->set_meta("viewport", viewport);
+
+            // canvas transform only available after the viewport canvas has been initialized
+            // on load the mask will not be the right size or offset, but will be corrected immediately on first update
+            Vector2i viewport_size = Vector2i(1,1);
+            Vector2 viewport_offset = Vector2(0,0);
+            viewport->set_size(viewport_size);
+            
+            mat->set_shader_parameter("tex_mask", viewport->get_texture());
+            mat->set_shader_parameter("canvas_size", Vector2(res.vct_canvas_size));
+            mat->set_shader_parameter("mesh_offset", viewport_offset);
         }
 
         res.dict_mesh[node_name] = node;
@@ -351,7 +356,7 @@ void InternalCubismRenderer2D::SaveProfile() {}
 void InternalCubismRenderer2D::RestoreProfile() {}
 
 // ------------------------------------------------------------------ method(s)
-PackedInt32Array make_PackedArrayInt32(const csmUint16 *ptr, const int32_t &size)
+PackedInt32Array make_Indices(const csmUint16 *ptr, const int32_t &size)
 {
     PackedInt32Array ary;
     ary.resize(size);
@@ -362,18 +367,18 @@ PackedInt32Array make_PackedArrayInt32(const csmUint16 *ptr, const int32_t &size
     return ary;
 }
 
-PackedVector2Array make_PackedArrayVector2(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size)
+PackedVector2Array make_UVs(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size)
 {
     PackedVector2Array ary;
     ary.resize(size);
     for (int i = 0; i < size; i++)
     {
-        ary.set(i, Vector2(ptr[i].X, ptr[i].Y));
+        ary.set(i, Vector2(ptr[i].X, 1.0 - ptr[i].Y));
     }
     return ary;
 }
 
-PackedVector2Array make_PackedArrayVector3(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size, const Csm::csmFloat32 &ppunit, const Vector2 &vct_adjust)
+PackedVector2Array make_Vertices(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size, const Csm::csmFloat32 &ppunit, const Vector2 &vct_adjust)
 {
     PackedVector2Array ary;
     ary.resize(size);

--- a/src/private/internal_cubism_renderer_2d.cpp
+++ b/src/private/internal_cubism_renderer_2d.cpp
@@ -28,7 +28,7 @@ using namespace godot;
 // ------------------------------------------------------------------ static(s)
 PackedInt32Array make_Indices(const csmUint16 *ptr, const int32_t &size);
 PackedVector2Array make_UVs(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size);
-PackedVector2Array make_Vertices(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size, const Csm::csmFloat32 &ppunit, const Vector2 &vct_adjust);
+PackedVector2Array make_Vertices(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size, const Csm::csmFloat32 &ppunit);
 const Vector4 make_vector4(const Live2D::Cubism::Core::csmVector4 &src_vec4);
 
 // ----------------------------------------------------------- class:forward(s)
@@ -81,8 +81,7 @@ void InternalCubismRenderer2D::update_mesh(
     ary[Mesh::ARRAY_VERTEX] = make_Vertices(
         model->GetDrawableVertexPositions(index),
         model->GetDrawableVertexCount(index),
-        res.CALCULATED_PPUNIT_C,
-        res.CALCULATED_ORIGIN_C);
+        res.CALCULATED_PPUNIT_C);
 
     ary[Mesh::ARRAY_TEX_UV] = make_UVs(
         model->GetDrawableVertexUvs(index),
@@ -378,13 +377,13 @@ PackedVector2Array make_UVs(const Live2D::Cubism::Core::csmVector2 *ptr, const i
     return ary;
 }
 
-PackedVector2Array make_Vertices(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size, const Csm::csmFloat32 &ppunit, const Vector2 &vct_adjust)
+PackedVector2Array make_Vertices(const Live2D::Cubism::Core::csmVector2 *ptr, const int32_t &size, const Csm::csmFloat32 &ppunit)
 {
     PackedVector2Array ary;
     ary.resize(size);
     for (int i = 0; i < size; i++)
     {
-        ary.set(i, (Vector2(ptr[i].X, ptr[i].Y * -1.0) * ppunit) + vct_adjust);
+        ary.set(i, Vector2(ptr[i].X, ptr[i].Y * -1.0) * ppunit);
     }
     return ary;
 }

--- a/src/private/internal_cubism_renderer_2d.hpp
+++ b/src/private/internal_cubism_renderer_2d.hpp
@@ -51,14 +51,14 @@ private:
         const Csm::csmInt32 index,
         const bool makemask,
         const InternalCubismRendererResource &res,
-        const Ref<ArrayMesh> ary_mesh) const;
+        const MeshInstance2D *node) const;
 
 public:
     Vector2 get_size(const Csm::CubismModel *model) const;
     Vector2 get_origin(const Csm::CubismModel *model) const;
     float get_ppunit(const Csm::CubismModel *model) const;
 
-    void update(InternalCubismRendererResource &res);
+    void update(InternalCubismRendererResource &res, int32_t viewport_size = 0);
     void build_model(InternalCubismRendererResource &res, Node *target_node);
 
     virtual void Initialize(Csm::CubismModel *model, Csm::csmInt32 maskBufferCount);

--- a/src/private/internal_cubism_renderer_resource.cpp
+++ b/src/private/internal_cubism_renderer_resource.cpp
@@ -23,8 +23,6 @@
 // ------------------------------------------------------------------- class(s)
 InternalCubismRendererResource::InternalCubismRendererResource(GDCubismUserModel *owner_viewport)
     : _owner_viewport(owner_viewport)
-    , adjust_pos(0.0, 0.0)
-    , adjust_scale(1.0)
 {
     ResourceLoader* res_loader = memnew(ResourceLoader);
 

--- a/src/private/internal_cubism_renderer_resource.hpp
+++ b/src/private/internal_cubism_renderer_resource.hpp
@@ -55,19 +55,11 @@ public:
     Array ary_shader;
     Dictionary dict_mesh;
     Dictionary dict_mask;
-    
-    // Adjust Parameters
-    Vector2 adjust_pos;
-    float adjust_scale;
 
     // Render parameters
     Vector2i vct_canvas_size;
-    Vector2i vct_mask_size;
-    float RATIO;
     float CALCULATED_PPUNIT_C;
-    float CALCULATED_PPUNIT_M;
     Vector2 CALCULATED_ORIGIN_C;
-    Vector2 CALCULATED_ORIGIN_M;
 };
 
 

--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -217,8 +217,10 @@ void InternalCubismUserModel::epi_update(const float delta) {
     if(this->_model_setting == nullptr) return;
     if(this->_model == nullptr) return;
 
-    if(this->_physics != nullptr) { this->_physics->Evaluate(this->_model, delta); }
-    if(this->_pose != nullptr) { this->_pose->UpdateParameters(this->_model, delta); }
+    if(this->_owner_viewport->parameter_mode == GDCubismUserModel::ParameterMode::FULL_PARAMETER) {
+        if(this->_physics != nullptr) { this->_physics->Evaluate(this->_model, delta); }
+        if(this->_pose != nullptr) { this->_pose->UpdateParameters(this->_model, delta); }
+    }
 
     this->_model->Update();
     this->effect_batch(delta, EFFECT_CALL_EPILOGUE);

--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -134,10 +134,6 @@ bool InternalCubismUserModel::model_load(
         #else
         #endif // GD_CUBISM_USE_RENDERER_2D
 
-        // Update Adjust Parameter(s)
-        this->_renderer_resource.adjust_scale = this->_owner_viewport->adjust_scale;
-        this->_renderer_resource.adjust_pos = this->_owner_viewport->adjust_pos;
-
         renderer->IsPremultipliedAlpha(false);
         renderer->DrawModel();
         renderer->build_model(this->_renderer_resource, this->_owner_viewport);
@@ -238,13 +234,9 @@ void InternalCubismUserModel::update_node() {
     #else
     #endif // GD_CUBISM_USE_RENDERER_2D
 
-    // Update Adjust Parameter(s)
-    this->_renderer_resource.adjust_scale = this->_owner_viewport->adjust_scale;
-    this->_renderer_resource.adjust_pos = this->_owner_viewport->adjust_pos;
-
     renderer->IsPremultipliedAlpha(false);
     renderer->DrawModel();
-    renderer->update(this->_renderer_resource);
+    renderer->update(this->_renderer_resource, this->_owner_viewport->mask_viewport_size);
 }
 
 

--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -217,8 +217,11 @@ void InternalCubismUserModel::epi_update(const float delta) {
     if(this->_model_setting == nullptr) return;
     if(this->_model == nullptr) return;
 
-    if(this->_owner_viewport->parameter_mode == GDCubismUserModel::ParameterMode::FULL_PARAMETER) {
+    if(this->_owner_viewport->physics_evaluate == true) {
         if(this->_physics != nullptr) { this->_physics->Evaluate(this->_model, delta); }
+    }
+
+    if(this->_owner_viewport->pose_update == true) {
         if(this->_pose != nullptr) { this->_pose->UpdateParameters(this->_model, delta); }
     }
 


### PR DESCRIPTION
~~currently builds on top of #124, leaving this as a draft PR until that is merged.~~ PR has been merged

Implements https://github.com/MizunagiKB/gd_cubism/issues/102

- GDCubismUserModel is now based on Node2D instead of Subviewport, allowing for direct rendering
- Mask shaders have been adjusted to work with this approach
- ~~mask_viewport_size as been changed to represent the shortest edge of the viewport texture, with its resolution matching the canvas aspect ratio to prevent visual errors~~ mask viewports are now dynamically sized based on mesh bounds to decrease memory requirements, users no longer need to manage mask scale

Adjust Pos and Adjust scale have been removed in favor of using position and scaling of Node2D.  As is standard practice in Godot, if you wish to adjust the offset of the model which is rendered from its TopLeft, simply wrap it with another Node2D.