### PR TITLE
Bugfix cubism effect

### DIFF
--- a/src/gd_cubism_effect.cpp
+++ b/src/gd_cubism_effect.cpp
@@ -17,11 +17,22 @@ void GDCubismEffect::_bind_methods() {
     ADD_PROPERTY(PropertyInfo(Variant::BOOL, "active"), "set_active", "get_active");
 }
 
+void GDCubismEffect::_cubism_init(InternalCubismUserModel* model) {
+    // This is a sample code. Please write the following code in the inherited class as needed:
 
-void GDCubismEffect::_cubism_init(InternalCubismUserModel* model) {}
+    if(this->_initialized == true) return;
+    // <Insert necessary processing here>
+    this->_initialized = true;
+}
 
 
-void GDCubismEffect::_cubism_term(InternalCubismUserModel* model) {}
+void GDCubismEffect::_cubism_term(InternalCubismUserModel* model) {
+    // This is a sample code. Please write the following code in the inherited class as needed:
+
+    if(this->_initialized == false) return;
+    // <Insert necessary processing here>
+    this->_initialized = false;
+}
 
 
 void GDCubismEffect::_cubism_prologue(InternalCubismUserModel* model, const float delta) {}

--- a/src/gd_cubism_effect.hpp
+++ b/src/gd_cubism_effect.hpp
@@ -28,6 +28,7 @@ class GDCubismEffect : public Node {
 
 protected:
     bool _active = true;
+    bool _initialized = false;
 
 protected:
     static void _bind_methods();

--- a/src/gd_cubism_effect_breath.hpp
+++ b/src/gd_cubism_effect_breath.hpp
@@ -39,7 +39,9 @@ private:
 
 public:
     virtual void _cubism_init(InternalCubismUserModel* model) override {
-        if(this->_initialized == false) {
+        if(this->_initialized == true) return;
+
+        if(this->_breath == nullptr) {
             Csm::ICubismModelSetting* _model_setting = model->_model_setting;
             this->_breath = Csm::CubismBreath::Create();
 
@@ -52,24 +54,25 @@ public:
             param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamBreath), 0.5f, 0.5f, 3.2345f, 0.5f));
 
             this->_breath->SetParameters(param);
-
-            this->_initialized = true;
         }
+
+        this->_initialized = true;
     }
 
     virtual void _cubism_term(InternalCubismUserModel* model) override {
-        if(this->_initialized == true) {
-            if(this->_breath != nullptr) {
-                Csm::CubismBreath::Delete(this->_breath);
-                this->_breath = nullptr;
-            }
-            this->_initialized = false;
+        if(this->_initialized == false) return;
+
+        if(this->_breath != nullptr) {
+            Csm::CubismBreath::Delete(this->_breath);
+            this->_breath = nullptr;
         }
+
+        this->_initialized = false;
     }
 
     virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
-        if(this->_breath == nullptr) return;
         if(this->_active == false) return;
+        if(this->_breath == nullptr) return;
         this->_breath->UpdateParameters(model->GetModel(), delta);
     }
 };

--- a/src/gd_cubism_effect_breath.hpp
+++ b/src/gd_cubism_effect_breath.hpp
@@ -71,8 +71,10 @@ public:
     }
 
     virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
+        if(this->_initialized == false) return;
         if(this->_active == false) return;
         if(this->_breath == nullptr) return;
+
         this->_breath->UpdateParameters(model->GetModel(), delta);
     }
 };

--- a/src/gd_cubism_effect_breath.hpp
+++ b/src/gd_cubism_effect_breath.hpp
@@ -39,24 +39,31 @@ private:
 
 public:
     virtual void _cubism_init(InternalCubismUserModel* model) override {
-        Csm::ICubismModelSetting* _model_setting = model->_model_setting;
-        this->_breath = Csm::CubismBreath::Create();
+        if(this->_initialized == false) {
+            Csm::ICubismModelSetting* _model_setting = model->_model_setting;
+            this->_breath = Csm::CubismBreath::Create();
 
-        Csm::csmVector<Csm::CubismBreath::BreathParameterData> param;
+            Csm::csmVector<Csm::CubismBreath::BreathParameterData> param;
 
-        param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamAngleX), 0.0f, 15.0f, 6.5345f, 0.5f));
-        param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamAngleY), 0.0f, 8.0f, 3.5345f, 0.5f));
-        param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamAngleZ), 0.0f, 10.0f, 5.5345f, 0.5f));
-        param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamBodyAngleX), 0.0f, 4.0f, 15.5345f, 0.5f));
-        param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamBreath), 0.5f, 0.5f, 3.2345f, 0.5f));
+            param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamAngleX), 0.0f, 15.0f, 6.5345f, 0.5f));
+            param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamAngleY), 0.0f, 8.0f, 3.5345f, 0.5f));
+            param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamAngleZ), 0.0f, 10.0f, 5.5345f, 0.5f));
+            param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamBodyAngleX), 0.0f, 4.0f, 15.5345f, 0.5f));
+            param.PushBack(Csm::CubismBreath::BreathParameterData(CubismFramework::GetIdManager()->GetId(ParamBreath), 0.5f, 0.5f, 3.2345f, 0.5f));
 
-        this->_breath->SetParameters(param);
+            this->_breath->SetParameters(param);
+
+            this->_initialized = true;
+        }
     }
 
     virtual void _cubism_term(InternalCubismUserModel* model) override {
-        if(this->_breath != nullptr) {
-            Csm::CubismBreath::Delete(this->_breath);
-            this->_breath = nullptr;
+        if(this->_initialized == true) {
+            if(this->_breath != nullptr) {
+                Csm::CubismBreath::Delete(this->_breath);
+                this->_breath = nullptr;
+            }
+            this->_initialized = false;
         }
     }
 

--- a/src/gd_cubism_effect_custom.hpp
+++ b/src/gd_cubism_effect_custom.hpp
@@ -53,16 +53,19 @@ public:
     }
 
     virtual void _cubism_prologue(InternalCubismUserModel* model, const float delta) override {
+        if(this->_initialized == false) return;
         if(this->_active == false) return;
         this->emit_signal("cubism_prologue", model->_owner_viewport, delta);
     }
 
     virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
+        if(this->_initialized == false) return;
         if(this->_active == false) return;
         this->emit_signal("cubism_process", model->_owner_viewport, delta);
     }
 
     virtual void _cubism_epilogue(InternalCubismUserModel* model, const float delta) override {
+        if(this->_initialized == false) return;
         if(this->_active == false) return;
         this->emit_signal("cubism_epilogue", model->_owner_viewport, delta);
     }

--- a/src/gd_cubism_effect_custom.hpp
+++ b/src/gd_cubism_effect_custom.hpp
@@ -37,17 +37,19 @@ protected:
 
 public:
     virtual void _cubism_init(InternalCubismUserModel* model) override {
-        if(this->_initialized == false) {
-            this->emit_signal("cubism_init", model->_owner_viewport);
-            this->_initialized = true;
-        }
+        if(this->_initialized == true) return;
+
+        this->emit_signal("cubism_init", model->_owner_viewport);
+
+        this->_initialized = true;
     }
 
     virtual void _cubism_term(InternalCubismUserModel* model) override {
-        if(this->_initialized == true) {
-            this->emit_signal("cubism_term", model->_owner_viewport);
-            this->_initialized = false;
-        }
+        if(this->_initialized == false) return;
+
+        this->emit_signal("cubism_term", model->_owner_viewport);
+
+        this->_initialized = false;
     }
 
     virtual void _cubism_prologue(InternalCubismUserModel* model, const float delta) override {

--- a/src/gd_cubism_effect_custom.hpp
+++ b/src/gd_cubism_effect_custom.hpp
@@ -37,11 +37,17 @@ protected:
 
 public:
     virtual void _cubism_init(InternalCubismUserModel* model) override {
-        this->emit_signal("cubism_init", model->_owner_viewport);
+        if(this->_initialized == false) {
+            this->emit_signal("cubism_init", model->_owner_viewport);
+            this->_initialized = true;
+        }
     }
 
     virtual void _cubism_term(InternalCubismUserModel* model) override {
-        this->emit_signal("cubism_term", model->_owner_viewport);
+        if(this->_initialized == true) {
+            this->emit_signal("cubism_term", model->_owner_viewport);
+            this->_initialized = false;
+        }
     }
 
     virtual void _cubism_prologue(InternalCubismUserModel* model, const float delta) override {

--- a/src/gd_cubism_effect_eye_blink.hpp
+++ b/src/gd_cubism_effect_eye_blink.hpp
@@ -56,6 +56,7 @@ public:
     }
 
     virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
+        if(this->_initialized == false) return;
         if(this->_active == false) return;
         if(this->_eye_blink == nullptr) return;
 

--- a/src/gd_cubism_effect_eye_blink.hpp
+++ b/src/gd_cubism_effect_eye_blink.hpp
@@ -32,27 +32,32 @@ private:
 
 public:
     virtual void _cubism_init(InternalCubismUserModel* model) override {
-        if(this->_initialized == false) {
+        if(this->_initialized == true) return;
+
+        if(this->_eye_blink == nullptr) {
             Csm::ICubismModelSetting* _model_setting = model->_model_setting;
-            if(_model_setting->GetEyeBlinkParameterCount() == 0) return;
-            this->_eye_blink = Csm::CubismEyeBlink::Create(_model_setting);
-            this->_initialized = true;
+            if(_model_setting->GetEyeBlinkParameterCount() > 0) {
+                this->_eye_blink = Csm::CubismEyeBlink::Create(_model_setting);
+            }
         }
+
+        this->_initialized = true;
     }
 
     virtual void _cubism_term(InternalCubismUserModel* model) override {
-        if(this->_initialized == true) {
-            if(this->_eye_blink != nullptr) {
-                Csm::CubismEyeBlink::Delete(this->_eye_blink);
-                this->_eye_blink = nullptr;
-            }
-            this->_initialized = false;
+        if(this->_initialized == false) return;
+
+        if(this->_eye_blink != nullptr) {
+            Csm::CubismEyeBlink::Delete(this->_eye_blink);
+            this->_eye_blink = nullptr;
         }
+
+        this->_initialized = false;
     }
 
     virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
-        if(this->_eye_blink == nullptr) return;
         if(this->_active == false) return;
+        if(this->_eye_blink == nullptr) return;
 
         this->_eye_blink->UpdateParameters(model->GetModel(), delta);
     }

--- a/src/gd_cubism_effect_eye_blink.hpp
+++ b/src/gd_cubism_effect_eye_blink.hpp
@@ -32,15 +32,21 @@ private:
 
 public:
     virtual void _cubism_init(InternalCubismUserModel* model) override {
-        Csm::ICubismModelSetting* _model_setting = model->_model_setting;
-        if(_model_setting->GetEyeBlinkParameterCount() == 0) return;
-        this->_eye_blink = Csm::CubismEyeBlink::Create(_model_setting);
+        if(this->_initialized == false) {
+            Csm::ICubismModelSetting* _model_setting = model->_model_setting;
+            if(_model_setting->GetEyeBlinkParameterCount() == 0) return;
+            this->_eye_blink = Csm::CubismEyeBlink::Create(_model_setting);
+            this->_initialized = true;
+        }
     }
 
     virtual void _cubism_term(InternalCubismUserModel* model) override {
-        if(this->_eye_blink != nullptr) {
-            Csm::CubismEyeBlink::Delete(this->_eye_blink);
-            this->_eye_blink = nullptr;
+        if(this->_initialized == true) {
+            if(this->_eye_blink != nullptr) {
+                Csm::CubismEyeBlink::Delete(this->_eye_blink);
+                this->_eye_blink = nullptr;
+            }
+            this->_initialized = false;
         }
     }
 

--- a/src/gd_cubism_effect_hit_area.hpp
+++ b/src/gd_cubism_effect_hit_area.hpp
@@ -56,7 +56,6 @@ protected:
 
 private:
     Vector2 _target;
-    bool _initialized = false;
     bool _target_update;
     bool _monitoring = true;
     Dictionary _dict_monitoring;
@@ -149,14 +148,18 @@ public:
     bool get_monitoring() const { return this->_monitoring; }
 
     virtual void _cubism_init(InternalCubismUserModel* internal_model) override {
-        if(internal_model == nullptr) return;
-        this->_dict_monitoring.clear();
-        this->_target_update = false;
-        this->_initialized = true;
+        if(this->_initialized == false) {
+            if(internal_model == nullptr) return;
+            this->_dict_monitoring.clear();
+            this->_target_update = false;
+            this->_initialized = true;
+        }
     }
 
     virtual void _cubism_term(InternalCubismUserModel* internal_model) override {
-        this->_initialized = false;
+        if(this->_initialized == true) {
+            this->_initialized = false;
+        }
     }
 
     virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {

--- a/src/gd_cubism_effect_hit_area.hpp
+++ b/src/gd_cubism_effect_hit_area.hpp
@@ -165,6 +165,7 @@ public:
     }
 
     virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
+        if(this->_initialized == false) return;
         if(this->_active == false) return;
 
         Csm::ICubismModelSetting* setting = model->_model_setting;

--- a/src/gd_cubism_effect_hit_area.hpp
+++ b/src/gd_cubism_effect_hit_area.hpp
@@ -56,7 +56,7 @@ protected:
 
 private:
     Vector2 _target;
-    bool _target_update;
+    bool _target_update = false;
     bool _monitoring = true;
     Dictionary _dict_monitoring;
 
@@ -147,19 +147,21 @@ public:
 
     bool get_monitoring() const { return this->_monitoring; }
 
-    virtual void _cubism_init(InternalCubismUserModel* internal_model) override {
-        if(this->_initialized == false) {
-            if(internal_model == nullptr) return;
-            this->_dict_monitoring.clear();
-            this->_target_update = false;
-            this->_initialized = true;
-        }
+    virtual void _cubism_init(InternalCubismUserModel* model) override {
+        if(this->_initialized == true) return;
+
+        this->_dict_monitoring.clear();
+        this->_target_update = false;
+
+        this->_initialized = true;
     }
 
-    virtual void _cubism_term(InternalCubismUserModel* internal_model) override {
-        if(this->_initialized == true) {
-            this->_initialized = false;
-        }
+    virtual void _cubism_term(InternalCubismUserModel* model) override {
+        if(this->_initialized == false) return;
+
+        this->_dict_monitoring.clear();
+
+        this->_initialized = false;
     }
 
     virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
@@ -194,9 +196,7 @@ public:
                 this->_dict_monitoring[id] = false;
             }
         }
-    }
 
-    virtual void _cubism_epilogue(InternalCubismUserModel* model, const float delta) override {
         this->_target_update = false;
     }
 };

--- a/src/gd_cubism_effect_target_point.hpp
+++ b/src/gd_cubism_effect_target_point.hpp
@@ -82,19 +82,19 @@ protected:
     }
 
 private:
-    void set_head_angle_x(const String id) { this->head_angle_x = id; this->initialized = false; }
+    void set_head_angle_x(const String id) { this->head_angle_x = id; this->_need_update = false; }
     String get_head_angle_x() const { return this->head_angle_x; }
-    void set_head_angle_y(const String id) { this->head_angle_y = id; this->initialized = false; }
+    void set_head_angle_y(const String id) { this->head_angle_y = id; this->_need_update = false; }
     String get_head_angle_y() const { return this->head_angle_y; }
-    void set_head_angle_z(const String id) { this->head_angle_z = id; this->initialized = false; }
+    void set_head_angle_z(const String id) { this->head_angle_z = id; this->_need_update = false; }
     String get_head_angle_z() const { return this->head_angle_z; }
 
-    void set_body_angle_x(const String id) { this->body_angle_x = id; this->initialized = false; }
+    void set_body_angle_x(const String id) { this->body_angle_x = id; this->_need_update = false; }
     String get_body_angle_x() const { return this->body_angle_x; }
 
-    void set_eyes_ball_x(const String id) { this->eyes_ball_x = id; this->initialized = false; }
+    void set_eyes_ball_x(const String id) { this->eyes_ball_x = id; this->_need_update = false; }
     String get_eyes_ball_x() const { return this->eyes_ball_x; }
-    void set_eyes_ball_y(const String id) { this->eyes_ball_y = id; this->initialized = false; }
+    void set_eyes_ball_y(const String id) { this->eyes_ball_y = id; this->_need_update = false; }
     String get_eyes_ball_y() const { return this->eyes_ball_y; }
 
 private:
@@ -111,7 +111,8 @@ private:
     Csm::csmFloat32 _eyesRange = 1.0;
 
     Csm::csmMap<E_PARAM, Csm::csmInt32> _map_param_idx;
-    bool initialized = false;
+
+    bool _need_update = false;
 
 private:
     Csm::csmInt32 find_idx(Csm::CubismModel* _model, const Csm::csmString name) const {
@@ -146,19 +147,24 @@ public:
     }
 
     virtual void _cubism_init(InternalCubismUserModel* model) override {
-        this->_target_point = memnew(Csm::CubismTargetPoint);
-        this->_target_point->Set(0.0, 0.0);
-        this->_map_param_idx.Clear();
-        this->initialized = false;
+        if(this->_initialized == false) {
+            this->_target_point = memnew(Csm::CubismTargetPoint);
+            this->_target_point->Set(0.0, 0.0);
+            this->_map_param_idx.Clear();
+            this->_initialized = true;
+        }
     }
 
     virtual void _cubism_term(InternalCubismUserModel* model) override {
+        if(this->_initialized == true) {
+            this->_map_param_idx.Clear();
 
-        this->_map_param_idx.Clear();
+            if(this->_target_point != nullptr) {
+                memdelete(this->_target_point);
+                this->_target_point = nullptr;
+            }
 
-        if(this->_target_point != nullptr) {
-            memdelete(this->_target_point);
-            this->_target_point = nullptr;
+            this->_initialized = false;
         }
     }
 
@@ -168,7 +174,7 @@ public:
  
         Csm::CubismModel* _model = model->GetModel();
 
-        if(this->initialized == false) {
+        if(this->_need_update == false) {
             Csm::csmInt32 v;
             // ANGLE_X
             v = this->find_idx(_model, Csm::csmString(this->head_angle_x.utf8().ptr()));
@@ -197,7 +203,7 @@ public:
             if(v == -1 && this->eyes_ball_y.length() > 0) WARN_PRINT_ED(String("Undefined parameter name: ") + this->eyes_ball_y);
             this->_map_param_idx[EYES_BALL_Y] = v;
 
-            this->initialized = true;
+            this->_need_update = true;
         }
 
         this->_target_point->Update(delta);

--- a/src/gd_cubism_effect_target_point.hpp
+++ b/src/gd_cubism_effect_target_point.hpp
@@ -171,6 +171,7 @@ public:
     }
 
     virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
+        if(this->_initialized == false) return;
         if(this->_active == false) return;
         if(this->_target_point == nullptr) return;
  

--- a/src/gd_cubism_effect_target_point.hpp
+++ b/src/gd_cubism_effect_target_point.hpp
@@ -82,19 +82,19 @@ protected:
     }
 
 private:
-    void set_head_angle_x(const String id) { this->head_angle_x = id; this->_need_update = false; }
+    void set_head_angle_x(const String id) { this->head_angle_x = id; this->_need_update = true; }
     String get_head_angle_x() const { return this->head_angle_x; }
-    void set_head_angle_y(const String id) { this->head_angle_y = id; this->_need_update = false; }
+    void set_head_angle_y(const String id) { this->head_angle_y = id; this->_need_update = true; }
     String get_head_angle_y() const { return this->head_angle_y; }
-    void set_head_angle_z(const String id) { this->head_angle_z = id; this->_need_update = false; }
+    void set_head_angle_z(const String id) { this->head_angle_z = id; this->_need_update = true; }
     String get_head_angle_z() const { return this->head_angle_z; }
 
-    void set_body_angle_x(const String id) { this->body_angle_x = id; this->_need_update = false; }
+    void set_body_angle_x(const String id) { this->body_angle_x = id; this->_need_update = true; }
     String get_body_angle_x() const { return this->body_angle_x; }
 
-    void set_eyes_ball_x(const String id) { this->eyes_ball_x = id; this->_need_update = false; }
+    void set_eyes_ball_x(const String id) { this->eyes_ball_x = id; this->_need_update = true; }
     String get_eyes_ball_x() const { return this->eyes_ball_x; }
-    void set_eyes_ball_y(const String id) { this->eyes_ball_y = id; this->_need_update = false; }
+    void set_eyes_ball_y(const String id) { this->eyes_ball_y = id; this->_need_update = true; }
     String get_eyes_ball_y() const { return this->eyes_ball_y; }
 
 private:
@@ -147,35 +147,38 @@ public:
     }
 
     virtual void _cubism_init(InternalCubismUserModel* model) override {
-        if(this->_initialized == false) {
+        if(this->_initialized == true) return;
+
+        if(this->_target_point == nullptr) {
             this->_target_point = memnew(Csm::CubismTargetPoint);
             this->_target_point->Set(0.0, 0.0);
-            this->_map_param_idx.Clear();
-            this->_initialized = true;
         }
+        this->_map_param_idx.Clear();
+
+        this->_initialized = true;
     }
 
     virtual void _cubism_term(InternalCubismUserModel* model) override {
-        if(this->_initialized == true) {
-            this->_map_param_idx.Clear();
+        if(this->_initialized == false) return;
 
-            if(this->_target_point != nullptr) {
-                memdelete(this->_target_point);
-                this->_target_point = nullptr;
-            }
-
-            this->_initialized = false;
+        this->_map_param_idx.Clear();
+        if(this->_target_point != nullptr) {
+            memdelete(this->_target_point);
+            this->_target_point = nullptr;
         }
+
+        this->_initialized = false;
     }
 
     virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
-        if(this->_target_point == nullptr) return;
         if(this->_active == false) return;
+        if(this->_target_point == nullptr) return;
  
         Csm::CubismModel* _model = model->GetModel();
 
-        if(this->_need_update == false) {
+        if(this->_need_update == true) {
             Csm::csmInt32 v;
+
             // ANGLE_X
             v = this->find_idx(_model, Csm::csmString(this->head_angle_x.utf8().ptr()));
             if(v == -1 && this->head_angle_x.length() > 0) WARN_PRINT_ED(String("Undefined parameter name: ") + this->head_angle_x);
@@ -203,7 +206,7 @@ public:
             if(v == -1 && this->eyes_ball_y.length() > 0) WARN_PRINT_ED(String("Undefined parameter name: ") + this->eyes_ball_y);
             this->_map_param_idx[EYES_BALL_Y] = v;
 
-            this->_need_update = true;
+            this->_need_update = false;
         }
 
         this->_target_point->Update(delta);

--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -265,6 +265,8 @@ void GDCubismUserModel::set_assets(const String assets) {
         }
     }
 
+    this->cubism_effect_dirty = true;
+
     this->setup_property();
     this->notify_property_list_changed();
 }

--- a/src/gd_cubism_value_parameter.hpp
+++ b/src/gd_cubism_value_parameter.hpp
@@ -48,6 +48,9 @@ private:
 protected:
     static void _bind_methods() {
 
+        ClassDB::bind_method(D_METHOD("get_type"), &GDCubismParameter::get_type);
+        ADD_PROPERTY(PropertyInfo(Variant::INT, "type", PROPERTY_HINT_ENUM, "Normal,BlendShape"), String(), "get_type");
+
         ClassDB::bind_method(D_METHOD("get_minimum_value"), &GDCubismParameter::get_minimum_value);
         ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "minimum_value"), String(), "get_minimum_value");
         ClassDB::bind_method(D_METHOD("get_maximum_value"), &GDCubismParameter::get_maximum_value);
@@ -86,6 +89,7 @@ public:
         : GDCubismValueAbs(GDCubismValueAbs::ValueType::PARAMETER) {}
 
     void reset() { this->set_value(this->default_value); this->hold = false; }
+    GDCubismParameter::Type get_type() const { return this->type; }
     float get_minimum_value() const { return this->minimum_value; }
     float get_maximum_value() const { return this->maximum_value; }
     float get_default_value() const { return this->default_value; }

--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -112,9 +112,6 @@ bool InternalCubismUserModel::model_load(const String &model_pathname) {
         this->motion_load();
     }
 
-    // GDCubismEffect
-    this->effect_init();
-
     this->CreateRenderer();
 
     // Resource(Texture)


### PR DESCRIPTION
This pull request addresses the bug reported here:  
> https://github.com/MizunagiKB/gd_cubism/issues/120

This **bug** occurs when replacing the model during execution, specifically within the `cubism_init` signal provided by `custom_effect`, where it attempts to reference the `GDCubismUserModel` information.

The cause of the issue is that the `cubism_init` signal is being called during the initialization of `GDCubismUserModel`.

To fix this issue, the `cubism_init` signal will no longer be called during the initialization of `GDCubismUserModel`. Instead, the update timing has been adjusted to align with Godot's update timing.

While this change delays the initialization timing in the code, it is not expected to cause any practical issues as there will still be an opportunity to update before rendering the Live2D model.

> This update pertains to the `cubism_effect` for **version 0.7**, and I will merge it into the **main branch** to provide it in the next version.
