### PR TITLE
Fixed type conversion error

### DIFF
--- a/demo/addons/gd_cubism/example/demo_effect_hit_area.gd
+++ b/demo/addons/gd_cubism/example/demo_effect_hit_area.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 
-const DEFAULT_ASSET: String = "res://addons/gd_cubism/example/res/live2d/mao_pro_jp/runtime/mao_pro_t02.model3.json"
+const DEFAULT_ASSET: String = "res://addons/gd_cubism/example/res/live2d/mao_pro_jp/runtime/mao_pro.model3.json"
 
 var pressed: bool = false
 var local_pos: Vector2 = Vector2.ZERO
@@ -80,4 +80,3 @@ func _on_canvas_draw():
 
 func _on_item_list_item_selected(index):
     id_mesh = $Control/ItemList.get_item_text(index)
-

--- a/demo/addons/gd_cubism/example/demo_effect_hit_area.tscn
+++ b/demo/addons/gd_cubism/example/demo_effect_hit_area.tscn
@@ -19,7 +19,6 @@ gui_disable_input = true
 render_target_update_mode = 4
 
 [node name="GDCubismEffectHitArea" type="GDCubismEffectHitArea" parent="Sprite2D/GDCubismUserModel"]
-monitoring = false
 
 [node name="Canvas" type="Control" parent="Sprite2D"]
 layout_mode = 3

--- a/src/gd_cubism_effect_hit_area.hpp
+++ b/src/gd_cubism_effect_hit_area.hpp
@@ -121,8 +121,9 @@ public:
         const Dictionary dict_mesh = model->get_meshes();
         if(dict_mesh.is_empty() == true) return Dictionary();
 
-        Ref<ArrayMesh> ref_ary_mesh = dict_mesh[id];
-        if(ref_ary_mesh.is_null() == true) return Dictionary();
+        MeshInstance2D* p_mesh_inst = cast_to<MeshInstance2D>(dict_mesh[id]);
+        Ref<ArrayMesh> ref_ary_mesh =  static_cast<ArrayMesh*>(p_mesh_inst->get_mesh().ptr());
+        if(ref_ary_mesh.is_valid() != true) return Dictionary();
         if(ref_ary_mesh->surface_get_array_index_len(0) < 3) return Dictionary();
 
         Dictionary dict_result;
@@ -176,7 +177,9 @@ public:
             const String id = static_cast<Dictionary>(ary[i]).get("id", String());
             if(dict_mesh.has(id) != true) continue;
 
-            Ref<ArrayMesh> ref_ary_mesh = dict_mesh[id];
+            MeshInstance2D* p_mesh_inst = cast_to<MeshInstance2D>(dict_mesh[id]);
+            Ref<ArrayMesh> ref_ary_mesh =  static_cast<ArrayMesh*>(p_mesh_inst->get_mesh().ptr());
+            if(ref_ary_mesh.is_valid() != true) continue;
             if(ref_ary_mesh->surface_get_array_index_len(0) < 3) continue;
 
             Rect2 check_rect = this->build_rect2(ref_ary_mesh);


### PR DESCRIPTION
Since version v0.8.0, there have been changes to the initialization and rendering methods of the Live2D model.

In previous versions, only `ArrayMesh` was stored, and this information was saved in `GDCubismEffectHitArea`.
However, in the current version, the information is saved directly in `MeshInstance2D` for more efficient processing.

Therefore, the previous `GDCubismEffectHitArea` code could not correctly retrieve the mesh information.

Previous version:
```cpp
Ref<ArrayMesh> ref_ary_mesh = dict_mesh[id];
if(ref_ary_mesh.is_null() == true) return Dictionary();
if(ref_ary_mesh->surface_get_array_index_len(0) < 3) return Dictionary();
```

The modifications to align with the current data structure are as follows:

Current version:
```cpp
MeshInstance2D* p_mesh_inst = cast_to<MeshInstance2D>(dict_mesh[id]);
Ref<ArrayMesh> ref_ary_mesh = static_cast<ArrayMesh*>(p_mesh_inst->get_mesh().ptr());
if(ref_ary_mesh.is_valid() != true) return Dictionary();
if(ref_ary_mesh->surface_get_array_index_len(0) < 3) return Dictionary();
```
