### PR TITLE
fix(GDCubismEffectTargetPoint): initialize `_need_update` to `true` to fix `_map_param_idx` initialization

### DIFF
--- a/src/gd_cubism_effect_target_point.hpp
+++ b/src/gd_cubism_effect_target_point.hpp
@@ -112,7 +112,7 @@ private:
 
     Csm::csmMap<E_PARAM, Csm::csmInt32> _map_param_idx;
 
-    bool _need_update = false;
+    bool _need_update = true;
 
 private:
     Csm::csmInt32 find_idx(Csm::CubismModel* _model, const Csm::csmString name) const {


### PR DESCRIPTION
Set `_need_update` to `true` by default in `GDCubismEffectTargetPoint` to ensure `_map_param_idx` is initialized correctly in `_cubism_process`.

The initial value of `_need_update` was `false`, which caused `_map_param_idx` to remain uninitialized when properties using default values. As a result, all values read from `_map_param_idx` were `0`, leading to incorrect behavior. This fix ensures that `_map_param_idx` is properly initialized during the first call to `_cubism_process`.