### PR TITLE
Bugfix none parameter mode

### DIFF
--- a/demo/addons/gd_cubism/cs/gd_cubism_user_model_cs.cs
+++ b/demo/addons/gd_cubism/cs/gd_cubism_user_model_cs.cs
@@ -186,6 +186,17 @@ public partial class GDCubismUserModelCS : GodotObject
     }
 
     /// <value>
+    ///     Property <c>PhysicsEvaluate</c>
+    ///     <br />
+    ///     Setting this parameter to `false` disables physical calculations.
+    /// </value>
+    public bool PhysicsEvaluate
+    {
+        set { this.InternalObject.Call("set_physics_evaluate", value); }
+        get { return (bool)this.InternalObject.Call("get_physics_evaluate"); }
+    }
+
+    /// <value>
     ///     Property <c>PlaybackProcessMode</c>
     ///     <br />
     ///     Specifies the playback method for the currently held Live2D model.
@@ -198,6 +209,18 @@ public partial class GDCubismUserModelCS : GodotObject
             int value = (int)this.InternalObject.Call("get_process_callback");
             return (MotionProcessCallbackEnum)Enum.ToObject(typeof(MotionProcessCallbackEnum), value);
         }
+    }
+
+    /// <value>
+    ///     Property <c>PoseUpdate</c>
+    ///     <br />
+    ///     Setting this parameter to `false` disables transparency calculations between drawing parts specified in the pose group.
+    ///     If you want to manually handle all transparency calculations, set this parameter to `false`.
+    /// </value>
+    public bool PoseUpdate
+    {
+        set { this.InternalObject.Call("set_pose_update", value); }
+        get { return (bool)this.InternalObject.Call("get_pose_update"); }
     }
 
     public Shader ShaderAdd

--- a/doc_classes/GDCubismUserModel.xml
+++ b/doc_classes/GDCubismUserModel.xml
@@ -200,8 +200,15 @@
 		<member name="parameter_mode" type="int" setter="set_parameter_mode" getter="get_parameter_mode" enum="GDCubismUserModel.ParameterMode" default="0">
 			Specifies the control method for the currently held Live2D model.
 		</member>
+		<member name="physics_evaluate" type="int" setter="set_physics_evaluate" getter="get_physics_evaluate" enum="GDCubismUserModel.PhysicsEvaluate" default="true">
+			Setting this parameter to [code]false[/code] disables physical calculations.
+		</member>
 		<member name="playback_process_mode" type="int" setter="set_process_callback" getter="get_process_callback" enum="GDCubismUserModel.MotionProcessCallback" default="1">
 			Specifies the playback method for the currently held Live2D model.
+		</member>
+		<member name="pose_update" type="int" setter="set_pose_update" getter="get_pose_update" enum="GDCubismUserModel.PoseUpdate" default="true">
+			Setting this parameter to [code]false[/code] disables transparency calculations between drawing parts specified in the pose group.
+			If you want to manually handle all transparency calculations, set this parameter to [code]false[/code].
 		</member>
 		<member name="shader_add" type="Shader" setter="set_shader_add" getter="get_shader_add">
 			Specifies the [i]shader[/i] used to render the Live2D model.

--- a/docs-src/modules/ROOT/pages/en/api/gd_cubism_user_model.adoc
+++ b/docs-src/modules/ROOT/pages/en/api/gd_cubism_user_model.adoc
@@ -35,7 +35,9 @@ This is a _SubViewport_ subclass for loading the Live2D model, generating the _T
 >|bool <|<<id-property-load_motions,load_motions>> |[default: true]
 >|Vector2i <|<<id-property-mask_viewport_size,mask_viewport_size>> |[default: Vector2i(0, 0)]
 >|ParameterMode <|<<id-property-parameter_mode,parameter_mode>> |[default: 0]
+>|bool <|<<physics_evaluate>> |[default: true]
 >|MotionProcessCallback <|<<id-property-playback_process_mode,playback_process_mode>> |[default: 1]
+>|bool <|<<pose_update>> |[default: true]
 >|Shader <|<<id-property-shader_add,shader_add>> |
 >|Shader <|<<id-property-shader_mask,shader_mask>> |
 >|Shader <|<<id-property-shader_mask_add,shader_mask_add>> |
@@ -209,9 +211,21 @@ Since GDCubism assumes the same aspect ratio as the Viewport for rendering, usin
 ParameterMode parameter_mode [default: 0]::
 Specifies the control method for the currently held Live2D model.
 
+
+[[id-property-physics_evaluate]]
+bool physics_evaluate [default: true]::
+Setting this parameter to `false` disables physical calculations.
+
+
 [[id-property-playback_process_mode]]
 MotionProcessCallback playback_process_mode [default: 1]::
 Specifies the playback method for the currently held Live2D model.
+
+
+[[id-property-pose_update]]
+bool pose_update [default: true]::
+Setting this parameter to `false` disables transparency calculations between drawing parts specified in the pose group. +
+If you want to manually handle all transparency calculations, set this parameter to `false`.
 
 
 [[id-property-shader_add]]

--- a/docs-src/modules/ROOT/pages/ja/api/gd_cubism_user_model.adoc
+++ b/docs-src/modules/ROOT/pages/ja/api/gd_cubism_user_model.adoc
@@ -22,6 +22,7 @@ endif::env-github,env-vscode[]
 Live2Dモデルを読み込み、表示に必要な _Texture_ を生成したり操作を行うための _SubVieport_ 継承クラスです。
 
 
+
 == Properties
 
 [cols="3",frame=none,grid=none]
@@ -32,8 +33,11 @@ Live2Dモデルを読み込み、表示に必要な _Texture_ を生成したり
 >|bool <|<<id-property-auto_scale,auto_scale>> |[default: true]
 >|bool <|<<id-property-load_expressions,load_expressions>> |[default: true]
 >|bool <|<<id-property-load_motions,load_motions>> |[default: true]
+>|Vector2i <|<<id-property-mask_viewport_size>> |[default: Vector2i(0, 0)]
 >|ParameterMode <|<<id-property-parameter_mode,parameter_mode>> |[default: 0]
+>|bool <|<<physics_evaluate>> |[default: true]
 >|MotionProcessCallback <|<<id-property-playback_process_mode,playback_process_mode>> |[default: 1]
+>|bool <|<<pose_update>> |[default: true]
 >|Shader <|<<id-property-shader_add,shader_add>> |
 >|Shader <|<<id-property-shader_mask,shader_mask>> |
 >|Shader <|<<id-property-shader_mask_add,shader_mask_add>> |
@@ -205,9 +209,20 @@ ParameterMode parameter_mode [default: 0]::
 現在保持しているLive2Dモデルのコントロール方法を指定します。
 
 
+[[id-property-physics_evaluate]]
+bool physics_evaluate [default: true]::
+_false_ にすると、物理計算を行わなくなります。
+
+
 [[id-property-playback_process_mode]]
 MotionProcessCallback playback_process_mode [default: 1]::
 現在保持しているLive2Dモデルの再生方法を指定します。
+
+
+[[id-property-pose_update]]
+bool pose_update [default: true]::
+_false_ にすると、ポーズグループに指定された描画パーツ同士で透明度の計算を行わなくなります。 +
+全ての透明度計算を手動で行いたい場合は _false_ にしてください。
 
 
 [[id-property-shader_add]]

--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -41,6 +41,8 @@ GDCubismUserModel::GDCubismUserModel()
     , adjust_pos(0.0, 0.0)
     , mask_viewport_size(0, 0)
     , parameter_mode(ParameterMode::FULL_PARAMETER)
+    , physics_evaluate(true)
+    , pose_update(true)
     , playback_process_mode(MotionProcessCallback::IDLE)
     , anim_loop(DEFAULT_PROP_ANIM_LOOP)
     , anim_loop_fade_in(DEFAULT_PROP_ANIM_LOOP_FADE_IN)
@@ -80,6 +82,14 @@ void GDCubismUserModel::_bind_methods() {
     ClassDB::bind_method(D_METHOD("set_parameter_mode", "value"), &GDCubismUserModel::set_parameter_mode);
     ClassDB::bind_method(D_METHOD("get_parameter_mode"), &GDCubismUserModel::get_parameter_mode);
     ADD_PROPERTY(PropertyInfo(Variant::INT, "parameter_mode", PROPERTY_HINT_ENUM, "FullParameter,NoneParameter"), "set_parameter_mode", "get_parameter_mode");
+
+    ClassDB::bind_method(D_METHOD("set_physics_evaluate", "enable"), &GDCubismUserModel::set_physics_evaluate);
+    ClassDB::bind_method(D_METHOD("get_physics_evaluate"), &GDCubismUserModel::get_physics_evaluate);
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_evaluate"), "set_physics_evaluate", "get_physics_evaluate");
+
+    ClassDB::bind_method(D_METHOD("set_pose_update", "enable"), &GDCubismUserModel::set_pose_update);
+    ClassDB::bind_method(D_METHOD("get_pose_update"), &GDCubismUserModel::get_pose_update);
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pose_update"), "set_pose_update", "get_pose_update");
 
     ClassDB::bind_method(D_METHOD("set_process_callback", "value"), &GDCubismUserModel::set_process_callback);
     ClassDB::bind_method(D_METHOD("get_process_callback"), &GDCubismUserModel::get_process_callback);

--- a/src/gd_cubism_user_model.hpp
+++ b/src/gd_cubism_user_model.hpp
@@ -115,6 +115,8 @@ public:
     Vector2i mask_viewport_size;
 
     ParameterMode parameter_mode;
+    bool physics_evaluate;
+    bool pose_update;
     MotionProcessCallback playback_process_mode;
 
     Array ary_shader;
@@ -158,6 +160,12 @@ public:
 
     void set_parameter_mode(const ParameterMode value);
     GDCubismUserModel::ParameterMode get_parameter_mode() const;
+
+    void set_physics_evaluate(const bool enable) { this->physics_evaluate = enable; }
+    bool get_physics_evaluate() const { return this->physics_evaluate; }
+
+    void set_pose_update(const bool enable) { this->pose_update = enable; }
+    bool get_pose_update() const { return this->pose_update; }
 
     void set_process_callback(const MotionProcessCallback value);
     GDCubismUserModel::MotionProcessCallback get_process_callback() const;

--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -217,8 +217,10 @@ void InternalCubismUserModel::epi_update(const float delta) {
     if(this->_model_setting == nullptr) return;
     if(this->_model == nullptr) return;
 
-    if(this->_physics != nullptr) { this->_physics->Evaluate(this->_model, delta); }
-    if(this->_pose != nullptr) { this->_pose->UpdateParameters(this->_model, delta); }
+    if(this->_owner_viewport->parameter_mode == GDCubismUserModel::ParameterMode::FULL_PARAMETER) {
+        if(this->_physics != nullptr) { this->_physics->Evaluate(this->_model, delta); }
+        if(this->_pose != nullptr) { this->_pose->UpdateParameters(this->_model, delta); }
+    }
 
     this->_model->Update();
     this->effect_batch(delta, EFFECT_CALL_EPILOGUE);

--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -217,8 +217,11 @@ void InternalCubismUserModel::epi_update(const float delta) {
     if(this->_model_setting == nullptr) return;
     if(this->_model == nullptr) return;
 
-    if(this->_owner_viewport->parameter_mode == GDCubismUserModel::ParameterMode::FULL_PARAMETER) {
+    if(this->_owner_viewport->physics_evaluate == true) {
         if(this->_physics != nullptr) { this->_physics->Evaluate(this->_model, delta); }
+    }
+
+    if(this->_owner_viewport->pose_update == true) {
         if(this->_pose != nullptr) { this->_pose->UpdateParameters(this->_model, delta); }
     }
 


### PR DESCRIPTION
This pull request addresses the following issues that arise when specifying the `NONE_PARAMETER` mode:

* Allow users to decide whether to apply Physics parameters in `NONE_PARAMETER` mode.
* Allow users to decide whether to fix part transparency using Pose files in `NONE_PARAMETER` mode.

By incorporating this pull request, users will have the option to decide whether to apply the Physics and Pose parameters set in the Live2D model.

![enable_physics_pose](https://github.com/user-attachments/assets/27d9b4d9-40c0-4178-9ec2-ef7addc1aefa)

The intended use case for this feature is when users want to automatically control the Physics settings of the Live2D model while playing animations using Godot Engine's `AnimationPlayer`.
