### PR TITLE
update shaders to support godot's canvasitem modulation

### DIFF
--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add.gdshader
@@ -16,11 +16,14 @@ uniform vec2 canvas_size;
 uniform vec2 mesh_offset;
 
 varying vec2 MASK_UV;
+varying vec4 modulate;
 
 void vertex() {
     vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
     vec2 mask_vtx = VERTEX - mesh_offset;
     MASK_UV = mask_vtx / mask_size;
+
+	modulate = COLOR;
 }
 
 void fragment() {
@@ -29,7 +32,7 @@ void fragment() {
 
     // premul alpha
     color_tex.rgb = color_tex.rgb + color_screen.rgb - (color_tex.rgb * color_screen.rgb);
-    vec4 color_for_mask = color_tex * color_base;
+    vec4 color_for_mask = color_tex * color_base * modulate;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
     vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_add_inv.gdshader
@@ -16,11 +16,14 @@ uniform vec2 canvas_size;
 uniform vec2 mesh_offset;
 
 varying vec2 MASK_UV;
+varying vec4 modulate;
 
 void vertex() {
     vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
     vec2 mask_vtx = VERTEX - mesh_offset;
     MASK_UV = mask_vtx / mask_size;
+
+	modulate = COLOR;
 }
 
 void fragment() {
@@ -29,7 +32,7 @@ void fragment() {
 
     // premul alpha
     color_tex.rgb = color_tex.rgb + color_screen.rgb - (color_tex.rgb * color_screen.rgb);
-    vec4 color_for_mask = color_tex * color_base;
+    vec4 color_for_mask = color_tex * color_base * modulate;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
     vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix.gdshader
@@ -16,11 +16,14 @@ uniform vec2 canvas_size;
 uniform vec2 mesh_offset;
 
 varying vec2 MASK_UV;
+varying vec4 modulate;
 
 void vertex() {
     vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
     vec2 mask_vtx = VERTEX - mesh_offset;
     MASK_UV = mask_vtx / mask_size;
+
+	modulate = COLOR;
 }
 
 void fragment() {
@@ -29,7 +32,7 @@ void fragment() {
 
     // premul alpha
     color_tex.rgb = color_tex.rgb + color_screen.rgb - (color_tex.rgb * color_screen.rgb);
-    vec4 color_for_mask = color_tex * color_base;
+    vec4 color_for_mask = color_tex * color_base * modulate;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
     vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mix_inv.gdshader
@@ -16,11 +16,14 @@ uniform vec2 canvas_size;
 uniform vec2 mesh_offset;
 
 varying vec2 MASK_UV;
+varying vec4 modulate;
 
 void vertex() {
     vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
     vec2 mask_vtx = VERTEX - mesh_offset;
     MASK_UV = mask_vtx / mask_size;
+
+	modulate = COLOR;
 }
 
 void fragment() {
@@ -29,7 +32,7 @@ void fragment() {
 
     // premul alpha
     color_tex.rgb = color_tex.rgb + color_screen.rgb - (color_tex.rgb * color_screen.rgb);
-    vec4 color_for_mask = color_tex * color_base;
+    vec4 color_for_mask = color_tex * color_base * modulate;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
     vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul.gdshader
@@ -16,11 +16,14 @@ uniform vec2 canvas_size;
 uniform vec2 mesh_offset;
 
 varying vec2 MASK_UV;
+varying vec4 modulate;
 
 void vertex() {
     vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
     vec2 mask_vtx = VERTEX - mesh_offset;
     MASK_UV = mask_vtx / mask_size;
+
+	modulate = COLOR;
 }
 
 void fragment() {
@@ -29,7 +32,7 @@ void fragment() {
 
     // premul alpha
     color_tex.rgb = color_tex.rgb + color_screen.rgb - (color_tex.rgb * color_screen.rgb);
-    vec4 color_for_mask = color_tex * color_base;
+    vec4 color_for_mask = color_tex * color_base * modulate;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
     vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul_inv.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_mask_mul_inv.gdshader
@@ -16,11 +16,14 @@ uniform vec2 canvas_size;
 uniform vec2 mesh_offset;
 
 varying vec2 MASK_UV;
+varying vec4 modulate;
 
 void vertex() {
     vec2 mask_size = vec2(textureSize(tex_mask, 0)) / mask_scale;
     vec2 mask_vtx = VERTEX - mesh_offset;
     MASK_UV = mask_vtx / mask_size;
+
+	modulate = COLOR;
 }
 
 void fragment() {
@@ -29,7 +32,7 @@ void fragment() {
 
     // premul alpha
     color_tex.rgb = color_tex.rgb + color_screen.rgb - (color_tex.rgb * color_screen.rgb);
-    vec4 color_for_mask = color_tex * color_base;
+    vec4 color_for_mask = color_tex * color_base * modulate;
     color_for_mask.rgb = color_for_mask.rgb * color_for_mask.a;
 
     vec4 clip_mask = texture(tex_mask, MASK_UV) * channel;

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_norm_add.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_norm_add.gdshader
@@ -10,12 +10,18 @@ uniform vec4 color_multiply : source_color;
 uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
 
+varying vec4 modulate;
+
+void vertex() {
+	modulate = COLOR;
+}
+
 void fragment() {
     vec4 color_tex = texture(tex_main, UV);
     color_tex.rgb = color_tex.rgb * color_multiply.rgb;
 
     // premul alpha
     color_tex.rgb = (color_tex.rgb + color_screen.rgb) - (color_tex.rgb * color_screen.rgb);
-    vec4 color = color_tex * color_base;
+    vec4 color = color_tex * color_base * modulate;
     COLOR = vec4(color.rgb * color.a, 0.0);
 }

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mix.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mix.gdshader
@@ -10,12 +10,18 @@ uniform vec4 color_multiply : source_color;
 uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
 
+varying vec4 modulate;
+
+void vertex() {
+	modulate = COLOR;
+}
+
 void fragment() {
     vec4 color_tex = texture(tex_main, UV);
     color_tex.rgb = color_tex.rgb * color_multiply.rgb;
 
     // premul alpha
     color_tex.rgb = (color_tex.rgb + color_screen.rgb) - (color_tex.rgb * color_screen.rgb);
-    vec4 color = color_tex * color_base;
+    vec4 color = color_tex * color_base * modulate;
     COLOR = vec4(color.rgb * color.a, color.a);
 }

--- a/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mul.gdshader
+++ b/demo/addons/gd_cubism/res/shader/2d_cubism_norm_mul.gdshader
@@ -10,12 +10,18 @@ uniform vec4 color_multiply : source_color;
 uniform vec4 channel : source_color;
 uniform sampler2D tex_main : filter_linear_mipmap;
 
+varying vec4 modulate;
+
+void vertex() {
+	modulate = COLOR;
+}
+
 void fragment() {
     vec4 color_tex = texture(tex_main, UV);
     color_tex.rgb = color_tex.rgb * color_multiply.rgb;
 
     // premul alpha
     color_tex.rgb = (color_tex.rgb + color_screen.rgb) - (color_tex.rgb * color_screen.rgb);
-    vec4 color = color_tex * color_base;
+    vec4 color = color_tex * color_base * modulate;
     COLOR = vec4(color.rgb * color.a, color.a);
 }


### PR DESCRIPTION
fixes #141 

This allows the provided shaders for gdcubism to respect the modulate and self_modulate properties on canvasitems.
I did not bother exposing new fields on GDCubismUserModel to control these values, but colors can freely be changed with scripting and accessing the generated mesh nodes.