### PR TITLE
Drag Operation Support for GDCubismUserModel

### DIFF
--- a/src/gd_cubism_effect.hpp
+++ b/src/gd_cubism_effect.hpp
@@ -22,6 +22,9 @@ using namespace godot;
 // ------------------------------------------------------------------- const(s)
 // ------------------------------------------------------------------ static(s)
 // ----------------------------------------------------------- class:forward(s)
+class InternalCubismUserModel;
+
+
 // ------------------------------------------------------------------- class(s)
 class GDCubismEffect : public Node {
     GDCLASS(GDCubismEffect, Node);

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,9 +1,203 @@
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------- include(s)
+#include <godot_cpp/classes/canvas_item.hpp>
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/editor_plugin.hpp>
+#include <godot_cpp/classes/editor_selection.hpp>
+#include <godot_cpp/classes/editor_settings.hpp>
+#include <godot_cpp/classes/input_event_mouse_button.hpp>
+#include <godot_cpp/classes/input_event_mouse_motion.hpp>
+#include <godot_cpp/classes/node2d.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/sub_viewport.hpp>
+
+#include <gd_cubism_user_model.hpp>
 #include <plugin.hpp>
 
+
+// ------------------------------------------------------------------ define(s)
+// --------------------------------------------------------------- namespace(s)
 using namespace godot;
 
-void GDCubismPlugin::_enter_tree() {
+
+// -------------------------------------------------------------------- enum(s)
+// ------------------------------------------------------------------- const(s)
+const char *SNAPMODE_LABEL = "Grid Snap";
+const bool SNAPMODE_INIT_VALUE = false;
+
+const char *SNAPSIZE_SUFFIX = "px";
+const double SNAPSIZE_MIN = 0;
+const double SNAPSIZE_MAX = 256;
+const double SNAPSIZE_STEP = 1;
+const double SNAPSIZE_INIT_VALUE = 8;
+
+
+// ----------------------------------------------------------- class:forward(s)
+// ------------------------------------------------------------------- class(s)
+Rect2 GDCubismPlugin::get_cubism_model_rect(GDCubismUserModel *model) const {
+    if (model == nullptr) return Rect2();
+    if (model->get_assets().length() == 0) return Rect2();
+    if (model->get_canvas_info().size() == 0) return Rect2();
+
+    Dictionary dict = model->get_canvas_info();
+    Vector2 size = dict["size_in_pixels"];
+    Vector2 orig = dict["origin_in_pixels"];
+
+    return Rect2(
+        model->get_global_position() + ((orig - size) * model->get_scale()),
+        size * model->get_scale()
+    );
 }
 
+bool GDCubismPlugin::update_selected_info() {
+    if (this->selected_model == nullptr) return false;
+    if (this->selected_model->get_assets().length() == 0) return false;
+    if (this->selected_model->get_canvas_info().size() == 0) return false;
+
+    this->selected_rect = this->get_cubism_model_rect(this->selected_model);
+
+    return true;
+}
+
+
+void GDCubismPlugin::_enter_tree() {
+
+    this->drag = false;
+
+    this->p_snapmode_button = memnew(Button);
+    this->p_snapmode_button->set_text(SNAPMODE_LABEL);
+    this->p_snapmode_button->set_toggle_mode(true);
+    this->p_snapmode_button->set_focus_mode(Control::FOCUS_NONE);
+    this->p_snapmode_button->set_pressed(SNAPMODE_INIT_VALUE);
+    this->add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, this->p_snapmode_button);
+
+    this->p_snapsize_spinbox = memnew(SpinBox);
+    this->p_snapsize_spinbox->set_suffix(SNAPSIZE_SUFFIX);
+    this->p_snapsize_spinbox->set_min(SNAPSIZE_MIN);
+    this->p_snapsize_spinbox->set_max(SNAPSIZE_MAX);
+    this->p_snapsize_spinbox->set_step(SNAPSIZE_STEP);
+    this->p_snapsize_spinbox->set_value(SNAPSIZE_INIT_VALUE);
+    this->p_snapsize_spinbox->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+    this->add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, this->p_snapsize_spinbox);
+}
+
+
 void GDCubismPlugin::_exit_tree() {
+
+    if (this->p_snapsize_spinbox != nullptr) {
+        this->remove_control_from_container(CONTAINER_CANVAS_EDITOR_MENU, this->p_snapsize_spinbox);
+        memdelete(this->p_snapsize_spinbox);
+        this->p_snapsize_spinbox = nullptr;
+    }
+
+    if (this->p_snapmode_button != nullptr) {
+        this->remove_control_from_container(CONTAINER_CANVAS_EDITOR_MENU, this->p_snapmode_button);
+        memdelete(this->p_snapmode_button);
+        this->p_snapmode_button = nullptr;
+    }
+}
+
+
+void GDCubismPlugin::_input(const Ref<InputEvent> &p_event) {
+
+    InputEventMouseButton* p_evt_mouse_button = Object::cast_to<InputEventMouseButton>(p_event.ptr());
+
+    if (p_evt_mouse_button != nullptr) {
+        Vector2 mouse_pos = get_editor_interface()->get_editor_viewport_2d()->get_mouse_position();
+
+        if (p_evt_mouse_button->get_button_index() == MOUSE_BUTTON_LEFT) {
+            if (p_evt_mouse_button->is_pressed() == true) {
+                TypedArray<Node> ary_node = get_tree()->get_edited_scene_root()->get_children();
+
+                for(int64_t i = 0; i < ary_node.size(); i++) {
+                    GDCubismUserModel *model = Object::cast_to<GDCubismUserModel>(ary_node[i]);
+                    if (model == nullptr) continue;
+                    if (get_cubism_model_rect(model).has_point(mouse_pos) == false) continue;
+                    if (get_editor_interface()->get_selection()->get_selected_nodes().size() > 1) continue;
+
+                    this->drag = true;
+                    this->drag_position = mouse_pos;
+                    this->base_position = model->get_global_position();
+
+                    get_editor_interface()->edit_node(model);
+                }
+            }
+        }
+    }
+}
+
+
+void GDCubismPlugin::_edit(Object *p_object) {
+    this->drag = false;
+    this->selected_model = Object::cast_to<GDCubismUserModel>(p_object);
+}
+
+
+bool GDCubismPlugin::_handles(Object *p_object) const {
+    return Object::cast_to<GDCubismUserModel>(p_object) != nullptr;
+}
+
+
+bool GDCubismPlugin::_forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
+
+    InputEventMouseButton *p_evt_mouse_button = Object::cast_to<InputEventMouseButton>(p_event.ptr());
+
+    if (p_evt_mouse_button != nullptr) {
+        Vector2 mouse_pos = this->get_editor_interface()->get_editor_viewport_2d()->get_mouse_position();
+
+        if (p_evt_mouse_button->get_button_index() == MOUSE_BUTTON_LEFT) {
+            if (p_evt_mouse_button->is_pressed() == true) {
+                if (this->update_selected_info() == true) {
+                    if (this->selected_rect.has_point(mouse_pos) == true) {
+                        this->drag = true;
+                        this->drag_position = mouse_pos;
+                        this->base_position = this->selected_model->get_global_position();
+
+                        return true;
+                    }
+                }
+            } else {
+                this->drag = false;
+            }
+        }
+    }
+
+    InputEventMouseMotion *p_evt_mouse_motion = Object::cast_to<InputEventMouseMotion>(p_event.ptr());
+
+    if (p_evt_mouse_motion != nullptr) {
+        Vector2 mouse_pos = this->get_editor_interface()->get_editor_viewport_2d()->get_mouse_position();
+
+        if (this->drag != true) return false;
+        if (this->selected_model == nullptr) return false;
+
+        Vector2 new_position = this->base_position + (mouse_pos - this->drag_position);
+
+        if (this->p_snapmode_button->is_pressed() == true) {
+            new_position.x = Math::snapped(new_position.x, this->p_snapsize_spinbox->get_value());
+            new_position.y = Math::snapped(new_position.y, this->p_snapsize_spinbox->get_value());
+        }
+
+        this->selected_model->set_global_position(new_position);
+
+        return true;
+    }
+
+    return false;
+}
+
+
+void GDCubismPlugin::_forward_canvas_draw_over_viewport(Control *p_viewport_control) {
+
+    if (this->update_selected_info() == true) {
+        Transform2D tform = this->get_editor_interface()->get_editor_viewport_2d()->get_global_canvas_transform();
+
+        p_viewport_control->draw_rect(
+            Rect2(
+                tform.xform(this->selected_rect.position),
+                this->selected_rect.size * tform.get_scale()
+            ),
+            this->selected_border_color,
+            false
+        );
+    }
 }

--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -6,18 +6,52 @@
 #include <godot_cpp/classes/global_constants.hpp>
 #include <godot_cpp/classes/editor_plugin.hpp>
 #include <godot_cpp/classes/animation.hpp>
+#include <godot_cpp/classes/control.hpp>
+#include <godot_cpp/classes/input_event.hpp>
+#include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/spin_box.hpp>
 
+// ------------------------------------------------------------------ define(s)
+// --------------------------------------------------------------- namespace(s)
 using namespace godot;
 
+// -------------------------------------------------------------------- enum(s)
+// ------------------------------------------------------------------- const(s)
+// ----------------------------------------------------------- class:forward(s)
+class GDCubismUserModel;
+
+// ------------------------------------------------------------------- class(s)
 class GDCubismPlugin : public EditorPlugin {
     GDCLASS(GDCubismPlugin, EditorPlugin);
 
+private:
+    const Color selected_border_color = Color(239.0 / 255.0, 120.0 / 255.0, 62.0 / 255.0, 1.0);
+
+    GDCubismUserModel *selected_model;
+    Rect2 selected_rect;
+    bool drag;
+    Vector2 drag_position;
+    Vector2 base_position;
+
+    Button *p_snapmode_button;
+    SpinBox *p_snapsize_spinbox;
+    
 protected:
-    static void _bind_methods() {};
+    static void _bind_methods() {}
+
+private:
+    Rect2 get_cubism_model_rect(GDCubismUserModel *selected_model) const;
+    bool update_selected_info();
 
 public:
     void _enter_tree() override;
     void _exit_tree() override;
+    void _input(const Ref<InputEvent> &p_event) override;
+
+    void _edit(Object *p_object) override;
+    bool _handles(Object *p_object) const override;
+    bool _forward_canvas_gui_input(const Ref<InputEvent> &p_event) override;
+    void _forward_canvas_draw_over_viewport(Control *p_viewport_control) override;
 };
 
 #endif // GD_CUBISM_PLUGIN

--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -41,6 +41,7 @@ protected:
 
 private:
     Rect2 get_cubism_model_rect(GDCubismUserModel *selected_model) const;
+    PackedVector2Array get_cubism_model_vertex(GDCubismUserModel *model) const;
     bool update_selected_info();
 
 public:


### PR DESCRIPTION
Currently, `GDCubismUserModel` inherits from `Node2D`, which limits drag operations to the `Node2D` axis only.

This pull request aims to enhance the editor experience by making it possible to drag Live2D models directly within the editor.

While this plugin works to a certain extent, the following issues remain:
- Rotation and skew operations are not supported (the model does not deform based on these values).
- Due to the lack of a method to retrieve information from `CanvasItemEditor`, a temporary snap-to-grid feature has been implemented separately.
- The behavior during multi-selection differs from the built-in editor (attempting to drag results in deselecting the current selection).

The `plugin.hpp` and `plugin.cpp` files were not originally designed for this functionality, leading to an increase in unrelated code.

From a personal perspective, the codebase feels disproportionately large for the provided functionality, raising the possibility of redundant redevelopment.

### Demo

https://github.com/user-attachments/assets/4204dad2-1642-492c-926b-40619cc68cc7



