### PR TITLE
fix mask transforms

### DIFF
--- a/src/private/internal_cubism_renderer_2d.cpp
+++ b/src/private/internal_cubism_renderer_2d.cpp
@@ -219,7 +219,7 @@ void InternalCubismRenderer2D::update(InternalCubismRendererResource &res, int32
 
         // optimize mask viewport size by scaling it relative to the viewport transform
         // maximum resolution should be equal to raw size from mesh dimensions, or the upper bound defined on the model
-        Vector2 mask_size = Math::min(bounds_in_viewport.size, canvas_bounds.size);
+        Vector2 mask_size = Math::min(canvas_bounds.size * node->get_global_scale(), canvas_bounds.size);
         Vector2 vp_scale = Vector2(mask_size) / Vector2(canvas_bounds.size);
         double scalar = 1.0;
         if (mask_viewport_size > 0) {

--- a/src/private/internal_cubism_renderer_2d.cpp
+++ b/src/private/internal_cubism_renderer_2d.cpp
@@ -85,20 +85,20 @@ void InternalCubismRenderer2D::update_mesh(
         for (int i = 0, n = 0; i < size; i++, n += sizeof(Vector2))
         {
             float x = ptr[i].X * pp_unit;
-            float y = ptr[i].Y * -1.0 * pp_unit;
-            vct_min.x = Math::min(vct_min.x, x);
-            vct_min.y = Math::min(vct_min.y, y);
-            vct_max.x = Math::max(vct_max.x, x);
-            vct_max.y = Math::max(vct_max.y, y);
+            float y = ptr[i].Y * pp_unit;
+            vct_min.x = Math::min(vct_min.x, x); // left
+            vct_min.y = Math::min(vct_min.y, y); // top
+            vct_max.x = Math::max(vct_max.x, x); // right
+            vct_max.y = Math::max(vct_max.y, y); // bottom
             
             ary.encode_float(n + offsetof(Vector2, x), x);
-            ary.encode_float(n + offsetof(Vector2, y), y);
+            ary.encode_float(n + offsetof(Vector2, y), -y);
         }
 
         ary_mesh->surface_update_vertex_region(0, 0, ary);
 
         // aabb does not get automatically updated when directly updating the vertex region
-        AABB aabb = AABB(vct_min, vct_max - vct_min);
+        AABB aabb(Vector3(vct_min.x, -vct_max.y, 0), vct_max - vct_min);
         ary_mesh->set_custom_aabb(aabb);
 
         return;


### PR DESCRIPTION
fixes masks being trimmed or culled when the model is rotated or skewed, as noted in #145.  

This appeared to be from using the global transformation to define the mask size and canvas transform of the mask.  Since masks are in subviewports they are unaffected by the parent transform.  The only factor we should be considering for the canvas transform of masks and their UVs is the scalar of the model's global transform.

Additionally, the custom AABBs had the wrong dimensions due to not taking into consideration the flipped Y coordinates.