### PR TITLE
share masks between nodes when composition is similar

### DIFF
--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -35,14 +35,14 @@ GDCubismUserModel::GDCubismUserModel()
     , enable_load_expressions(true)
     , enable_load_motions(true)
     , speed_scale(1.0)
-    , mask_viewport_size(0)
     , parameter_mode(ParameterMode::FULL_PARAMETER)
     , physics_evaluate(true)
     , pose_update(true)
     , playback_process_mode(MotionProcessCallback::IDLE)
     , anim_loop(DEFAULT_PROP_ANIM_LOOP)
     , anim_loop_fade_in(DEFAULT_PROP_ANIM_LOOP_FADE_IN)
-    , cubism_effect_dirty(false) {
+    , cubism_effect_dirty(false)
+    , mask_viewport_size(0) {
 
     this->ary_shader.resize(GD_CUBISM_SHADER_MAX);
 }
@@ -97,7 +97,7 @@ void GDCubismUserModel::_bind_methods() {
 
     ClassDB::bind_method(D_METHOD("set_mask_viewport_size", "value"), &GDCubismUserModel::set_mask_viewport_size);
     ClassDB::bind_method(D_METHOD("get_mask_viewport_size"), &GDCubismUserModel::get_mask_viewport_size);
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "mask_viewport_size", PROPERTY_HINT_RANGE, "0, 4096"), "set_mask_viewport_size", "get_mask_viewport_size");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "mask_viewport_size", PROPERTY_HINT_RANGE, "0,4096"), "set_mask_viewport_size", "get_mask_viewport_size");
 
     ClassDB::bind_method(D_METHOD("set_shader_add"), &GDCubismUserModel::set_shader_add);
     ClassDB::bind_method(D_METHOD("get_shader_add"), &GDCubismUserModel::get_shader_add);

--- a/src/private/internal_cubism_renderer_2d.cpp
+++ b/src/private/internal_cubism_renderer_2d.cpp
@@ -7,6 +7,7 @@
 #include <godot_cpp/classes/shader_material.hpp>
 #include <godot_cpp/classes/viewport_texture.hpp>
 #include <godot_cpp/classes/rendering_server.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
 
 #include <CubismFramework.hpp>
 #include <Model/CubismModel.hpp>
@@ -168,6 +169,7 @@ void InternalCubismRenderer2D::update(InternalCubismRendererResource &res, int32
         model,
         res);
 
+    // update meshes
     for (Csm::csmInt32 index = 0; index < model->GetDrawableCount(); index++)
     {
         if (model->GetDrawableVertexCount(index) == 0)
@@ -197,30 +199,28 @@ void InternalCubismRenderer2D::update(InternalCubismRendererResource &res, int32
             node->get_canvas_item(), true,
             canvas_bounds
         );
+    }
 
-        if (!node->has_meta("viewport")) continue;
+    // update masks
+    Array masks = res.dict_mask.keys();
+    for (int i = 0; i < masks.size(); i++) {
+        String mask_name = masks[i];
+        SubViewport *mask = Object::cast_to<SubViewport>(res.dict_mask[mask_name]);
 
-        SubViewport *viewport = Object::cast_to<SubViewport>(node->get_meta("viewport"));
-        
-        // detect if the canvas item is going to be culled
-        // only cull viewports when not looking at the model in the editor
-        Rect2 bounds_in_viewport = node->get_global_transform_with_canvas().xform(canvas_bounds);
-        const bool is_culled = 
-            !Engine::get_singleton()->is_editor_hint() &&
-            !(
-                node->get_viewport_rect().intersects(bounds_in_viewport) 
-                || node->get_viewport_rect().encloses(bounds_in_viewport)
-            );
+        // build bounding box of all the meshes in the viewport
+        AABB aabb;
+        {
+            Ref<ArrayMesh> mesh = Object::cast_to<MeshInstance2D>(mask->get_child(0))->get_mesh();
+            aabb = mesh->get_custom_aabb();
 
-        if (!visible || is_culled){
-            viewport->set_size(Vector2i(2,2));
-            continue;
+            for (int n = 1; n < mask->get_child_count(); n++) {
+                Ref<ArrayMesh> mesh = Object::cast_to<MeshInstance2D>(mask->get_child(n))->get_mesh();
+                aabb = aabb.merge(mesh->get_custom_aabb());
+            }
         }
+        aabb = aabb.grow(4.0);
 
-        // optimize mask viewport size by scaling it relative to the viewport transform
-        // maximum resolution should be equal to raw size from mesh dimensions, or the upper bound defined on the model
-        Vector2 mask_size = Math::min(canvas_bounds.size * node->get_global_scale(), canvas_bounds.size);
-        Vector2 vp_scale = Vector2(mask_size) / Vector2(canvas_bounds.size);
+        Vector2 mask_size = Vector2(aabb.size.x, aabb.size.y);
         double scalar = 1.0;
         if (mask_viewport_size > 0) {
             if (mask_size.x > mask_viewport_size || mask_size.y > mask_viewport_size) {
@@ -233,15 +233,20 @@ void InternalCubismRenderer2D::update(InternalCubismRendererResource &res, int32
             }
         }
 
-        Vector2 viewport_offset = Vector2(bounds.position.x, bounds.position.y);
+        Vector2 viewport_offset = Vector2(aabb.position.x, aabb.position.y);
         Transform2D transform = Transform2D(0, -viewport_offset);
-        transform.scale(Size2(scalar, scalar) * vp_scale);
-        viewport->set_size(mask_size);
-        viewport->set_canvas_transform(transform);
+        transform.scale(Vector2(scalar, scalar));
+        mask->set_size(mask_size);
+        mask->set_canvas_transform(transform);
 
-        mat->set_shader_parameter("tex_mask", viewport->get_texture());
-        mat->set_shader_parameter("mask_scale", scalar * vp_scale.x);
-        mat->set_shader_parameter("mesh_offset", viewport_offset);
+        Array meshes = res.dict_mask_meshes[mask_name];
+        for (int n = 0; n < meshes.size(); n++) {
+            MeshInstance2D *mesh = Object::cast_to<MeshInstance2D>(meshes[n]);
+            Ref<ShaderMaterial> mat = mesh->get_material();
+            mat->set_shader_parameter("tex_mask", mask->get_texture());
+            mat->set_shader_parameter("mask_scale", scalar);
+            mat->set_shader_parameter("mesh_offset", viewport_offset);
+        }
     }
 }
 
@@ -281,67 +286,97 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res, 
         node->set_material(mat);        
         node->set_name(node_name);
 
-        // build mask
-        if (model->GetDrawableMaskCounts()[index] > 0)
+        res.dict_mesh[node_name] = node;
+        target_node->add_child(node);
+        res.managed_nodes.append(node);
+
+        // node has a mask
+        if (model->GetDrawableMaskCounts()[index] <= 0)
+            continue;
+        
+        // calculate name based on referenced art mesh names composing the mask
+        Array mask_names;
+        for (Csm::csmInt32 m_index = 0; m_index < model->GetDrawableMaskCounts()[index]; m_index++)
         {
-            TypedArray<MeshInstance2D> masks;
-            masks.resize(model->GetDrawableMaskCounts()[index]);
+            Csm::csmInt32 j = model->GetDrawableMasks()[index][m_index];
             
+            if (model->GetDrawableVertexCount(j) == 0)
+                continue;
+            if (model->GetDrawableVertexIndexCount(j) == 0)
+                continue;
+    
+            CubismIdHandle handle = model->GetDrawableId(j);
+            String mask_name(handle->GetString().GetRawString());
+            mask_names.append(mask_name);
+        }
+
+        if (mask_names.is_empty())
+            continue;
+
+        // sort mask ids to gurantee consistency in hashing
+        mask_names.sort();
+
+        String mask_hash = String::num_int64(String("|").join(mask_names).hash());
+
+        // tag mesh node as dependent on a mask if one has already been created with the same composition
+        Array vp_meshes = res.dict_mask_meshes.get(mask_hash, Array());
+        vp_meshes.append(node);
+
+        // build a new mask
+        if (!res.dict_mask.has(mask_hash)) {
             SubViewport* viewport = memnew(SubViewport);
-            {
-                viewport->set_disable_3d(SUBVIEWPORT_DISABLE_3D_FLAG);
-                viewport->set_clear_mode(SubViewport::ClearMode::CLEAR_MODE_ALWAYS);
-                // set_update_mode must be specified
-                viewport->set_update_mode(SubViewport::UpdateMode::UPDATE_ALWAYS);
-                viewport->set_disable_input(true);
-                // Memory leak when set_use_own_world_3d is true
-                // https://github.com/godotengine/godot/issues/81476
-                viewport->set_use_own_world_3d(SUBVIEWPORT_USE_OWN_WORLD_3D_FLAG);
-                // Memory leak when set_transparent_background is true(* every time & window minimize)
-                // https://github.com/godotengine/godot/issues/89651
-                viewport->set_transparent_background(true);
 
-                for (Csm::csmInt32 m_index = 0; m_index < model->GetDrawableMaskCounts()[index]; m_index++)
-                {
-                    Csm::csmInt32 j = model->GetDrawableMasks()[index][m_index];
-                    
-                    if (model->GetDrawableVertexCount(j) == 0)
-                        continue;
-                    if (model->GetDrawableVertexIndexCount(j) == 0)
-                        continue;
+            res.dict_mask[mask_hash] = viewport;
             
-                    CubismIdHandle handle = model->GetDrawableId(j);
-                    String mask_name(handle->GetString().GetRawString());
+            viewport->set_name(mask_hash + "__mask");
 
-                    MeshInstance2D* node = res.request_mesh_instance();
-                    if (meshes[j]) {
-                        node->set_mesh(meshes[j]);
-                    } else {
-                        meshes[j] = node->get_mesh();
-                        this->update_mesh(model, j, res, node->get_mesh());
-                    }
-                    ShaderMaterial *mat = res.request_mask_material();
+            viewport->set_disable_3d(SUBVIEWPORT_DISABLE_3D_FLAG);
+            viewport->set_clear_mode(SubViewport::ClearMode::CLEAR_MODE_ALWAYS);
+            // set_update_mode must be specified
+            viewport->set_update_mode(SubViewport::UpdateMode::UPDATE_ALWAYS);
+            viewport->set_disable_input(true);
+            // Memory leak when set_use_own_world_3d is true
+            // https://github.com/godotengine/godot/issues/81476
+            viewport->set_use_own_world_3d(SUBVIEWPORT_USE_OWN_WORLD_3D_FLAG);
+            // Memory leak when set_transparent_background is true(* every time & window minimize)
+            // https://github.com/godotengine/godot/issues/89651
+            viewport->set_transparent_background(true);
 
-                    node->set_name(mask_name);
-                    node->set_material(mat);
-                    mat->set_shader_parameter("channel", Vector4(0.0, 0.0, 0.0, 1.0));
-                    mat->set_shader_parameter("tex_main", res.ary_texture[model->GetDrawableTextureIndex(index)]);
+            for (Csm::csmInt32 m_index = 0; m_index < model->GetDrawableMaskCounts()[index]; m_index++)
+            {
+                Csm::csmInt32 j = model->GetDrawableMasks()[index][m_index];
+                
+                if (model->GetDrawableVertexCount(j) == 0)
+                    continue;
+                if (model->GetDrawableVertexIndexCount(j) == 0)
+                    continue;
+        
+                CubismIdHandle handle = model->GetDrawableId(j);
+                String mask_name(handle->GetString().GetRawString());
 
-                    node->set_z_index(model->GetDrawableRenderOrders()[index]);
-                    node->set_visible(true);
-
-                    masks[m_index] = node;
-
-                    viewport->add_child(node);
-                    res.managed_nodes.append(node);
+                MeshInstance2D* node = res.request_mesh_instance();
+                if (meshes[j]) {
+                    node->set_mesh(meshes[j]);
+                } else {
+                    meshes[j] = node->get_mesh();
+                    this->update_mesh(model, j, res, node->get_mesh());
                 }
+                ShaderMaterial *mat = res.request_mask_material();
+
+                node->set_name(mask_name);
+                node->set_material(mat);
+                mat->set_shader_parameter("channel", Vector4(0.0, 0.0, 0.0, 1.0));
+                mat->set_shader_parameter("tex_main", res.ary_texture[model->GetDrawableTextureIndex(index)]);
+
+                node->set_z_index(model->GetDrawableRenderOrders()[index]);
+                node->set_visible(true);
+
+                viewport->add_child(node);
+                res.managed_nodes.append(node);
             }
 
             target_node->add_child(viewport);
             res.managed_nodes.append(viewport);
-
-            viewport->set_name(node_name + "__mask");
-            res.dict_mask[node_name] = masks;
 
             node->set_meta("viewport", viewport);
 
@@ -350,15 +385,13 @@ void InternalCubismRenderer2D::build_model(InternalCubismRendererResource &res, 
             Vector2i viewport_size = Vector2i(1,1);
             Vector2 viewport_offset = Vector2(0,0);
             viewport->set_size(viewport_size);
-            
+
             mat->set_shader_parameter("tex_mask", viewport->get_texture());
             mat->set_shader_parameter("canvas_size", Vector2(res.vct_canvas_size));
             mat->set_shader_parameter("mesh_offset", viewport_offset);
         }
 
-        res.dict_mesh[node_name] = node;
-        target_node->add_child(node);
-        res.managed_nodes.append(node);
+        res.dict_mask_meshes[mask_hash] = vp_meshes;
     }
 }
 

--- a/src/private/internal_cubism_renderer_resource.cpp
+++ b/src/private/internal_cubism_renderer_resource.cpp
@@ -64,6 +64,7 @@ void InternalCubismRendererResource::clear() {
     this->ary_texture.clear();
     this->dict_mesh.clear();
     this->dict_mask.clear();
+    this->dict_mask_meshes.clear();
 }
 
 MeshInstance2D* InternalCubismRendererResource::request_mesh_instance() {

--- a/src/private/internal_cubism_renderer_resource.hpp
+++ b/src/private/internal_cubism_renderer_resource.hpp
@@ -55,6 +55,7 @@ public:
     Array ary_shader;
     Dictionary dict_mesh;
     Dictionary dict_mask;
+    Dictionary dict_mask_meshes;
 
     // Render parameters
     Vector2i vct_canvas_size;


### PR DESCRIPTION
Changes the approach of masking

- meshes with the same mask composition now share a single viewport
- mask viewport is sized based on the bounding box of the meshes composing the mask, instead of the mesh being masked

High quality models with many masked meshes should see a significant improvement thanks to less subviewport textures in use.

Users may not see any improvement in possible edge cases of
- models with many meshes that have little to no reuse in mask composition (this is at worst going to be equal to having a viewport per mesh as before)
- composite masks in large canvases where the meshes composing the mask are spaced far apart

GPU Usage % is improved thanks to less subviewports being managed and written to.
VRAM is improved thanks to less subviewports, and those that exist the AABB is typically smaller than the sum of meshes being masked.

Mask viewports are no longer dynamically sized based on the mesh perceived scale, since the performance improvements negated much of the need to.  I was also encountering rendering issues when being too aggressive in downscaling.  I still see VRAM benefits when using the max viewport size setting, but even at max resolution the VRAM usage is reasonable. 

I may dig into restoring some sort of automation for resizing viewports, or at very least culling masks that are off screen, but it's not as critical as before.