### PR TITLE
Fix for Incorrect Data Type

### DIFF
--- a/demo/addons/gd_cubism/cs/gd_cubism_effect_custom_cs.cs
+++ b/demo/addons/gd_cubism/cs/gd_cubism_effect_custom_cs.cs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2023 MizunagiKB <mizukb@live.jp>
-using System;
 using Godot;
 using Godot.NativeInterop;
 
@@ -24,7 +23,7 @@ public partial class GDCubismEffectCustomCS : GDCubismEffectCS
     // -------------------------------------------------------------- Method(s)
     // -------------------------------------------------------------- Signal(s)
 
-    public delegate void CubismEpilogueEventHandler(Node2D value, float delta);
+    public delegate void CubismEpilogueEventHandler(Node2D value, double delta);
 
     private static void CubismEpilogueTrampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
     {
@@ -57,7 +56,7 @@ public partial class GDCubismEffectCustomCS : GDCubismEffectCS
         remove => this.InternalObject.Disconnect(CubismInitName, Callable.CreateWithUnsafeTrampoline(value, &CubismInitrampoline));
     }
 
-    public delegate void CubsimPrologueEventHandler(Node2D value, float delta);
+    public delegate void CubsimPrologueEventHandler(Node2D value, double delta);
 
     private static void CubismPrologueTrampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
     {
@@ -74,7 +73,7 @@ public partial class GDCubismEffectCustomCS : GDCubismEffectCS
         remove => this.InternalObject.Disconnect(CubismPrologueName, Callable.CreateWithUnsafeTrampoline(value, &CubismPrologueTrampoline));
     }
 
-    public delegate void CubismProcessEventHandler(Node2D value, float delta);
+    public delegate void CubismProcessEventHandler(Node2D value, double delta);
 
     private static void CubismProcessTrampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
     {

--- a/demo/addons/gd_cubism/cs/gd_cubism_user_model_cs.cs
+++ b/demo/addons/gd_cubism/cs/gd_cubism_user_model_cs.cs
@@ -279,7 +279,7 @@ public partial class GDCubismUserModelCS : GodotObject
     ///     Please specify a value of 0.0 or more for delta.
     /// </summary>
     /// <param name="delta">The time to progress the animation.</param>
-    public void Advance(float delta)
+    public void Advance(double delta)
     {
         this.InternalObject.Call("advance", delta);
     }

--- a/demo/addons/gd_cubism/example/demo_effect_custom_02.cs
+++ b/demo/addons/gd_cubism/example/demo_effect_custom_02.cs
@@ -70,7 +70,7 @@ public partial class demo_effect_custom_02 : Node2D
         recalc_model_position(this.cubism_model);
     }
 
-    private void _on_cubism_process(Node2D model, float delta)
+    private void _on_cubism_process(Node2D model, double delta)
     {
         const int ARRAY_VERTEX = (int)ArrayMesh.ArrayType.Vertex;
 

--- a/demo/addons/gd_cubism/example/demo_effect_custom_03.cs
+++ b/demo/addons/gd_cubism/example/demo_effect_custom_03.cs
@@ -101,7 +101,7 @@ public partial class demo_effect_custom_03 : Node2D
         this.history_position = 0;
     }
 
-    private void _on_cubism_process(Node2D _model, float delta)
+    private void _on_cubism_process(Node2D _model, double delta)
     {
         if (this.lipsync_ready == false) return;
 

--- a/src/gd_cubism_effect.cpp
+++ b/src/gd_cubism_effect.cpp
@@ -35,9 +35,9 @@ void GDCubismEffect::_cubism_term(InternalCubismUserModel* model) {
 }
 
 
-void GDCubismEffect::_cubism_prologue(InternalCubismUserModel* model, const float delta) {}
-void GDCubismEffect::_cubism_process(InternalCubismUserModel* model, const float delta) {}
-void GDCubismEffect::_cubism_epilogue(InternalCubismUserModel* model, const float delta) {}
+void GDCubismEffect::_cubism_prologue(InternalCubismUserModel* model, const double delta) {}
+void GDCubismEffect::_cubism_process(InternalCubismUserModel* model, const double delta) {}
+void GDCubismEffect::_cubism_epilogue(InternalCubismUserModel* model, const double delta) {}
 
 
 void GDCubismEffect::_enter_tree() {

--- a/src/gd_cubism_effect.hpp
+++ b/src/gd_cubism_effect.hpp
@@ -42,9 +42,9 @@ public:
 
     virtual void _cubism_init(InternalCubismUserModel* model);
     virtual void _cubism_term(InternalCubismUserModel* model);
-    virtual void _cubism_prologue(InternalCubismUserModel* model, const float delta);
-    virtual void _cubism_process(InternalCubismUserModel* model, const float delta);
-    virtual void _cubism_epilogue(InternalCubismUserModel* model, const float delta);
+    virtual void _cubism_prologue(InternalCubismUserModel* model, const double delta);
+    virtual void _cubism_process(InternalCubismUserModel* model, const double delta);
+    virtual void _cubism_epilogue(InternalCubismUserModel* model, const double delta);
 
     void _enter_tree() override;
     void _exit_tree() override;

--- a/src/gd_cubism_effect_breath.hpp
+++ b/src/gd_cubism_effect_breath.hpp
@@ -70,7 +70,7 @@ public:
         this->_initialized = false;
     }
 
-    virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
+    virtual void _cubism_process(InternalCubismUserModel* model, const double delta) override {
         if(this->_initialized == false) return;
         if(this->_active == false) return;
         if(this->_breath == nullptr) return;

--- a/src/gd_cubism_effect_custom.hpp
+++ b/src/gd_cubism_effect_custom.hpp
@@ -52,19 +52,19 @@ public:
         this->_initialized = false;
     }
 
-    virtual void _cubism_prologue(InternalCubismUserModel* model, const float delta) override {
+    virtual void _cubism_prologue(InternalCubismUserModel* model, const double delta) override {
         if(this->_initialized == false) return;
         if(this->_active == false) return;
         this->emit_signal("cubism_prologue", model->_owner_viewport, delta);
     }
 
-    virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
+    virtual void _cubism_process(InternalCubismUserModel* model, const double delta) override {
         if(this->_initialized == false) return;
         if(this->_active == false) return;
         this->emit_signal("cubism_process", model->_owner_viewport, delta);
     }
 
-    virtual void _cubism_epilogue(InternalCubismUserModel* model, const float delta) override {
+    virtual void _cubism_epilogue(InternalCubismUserModel* model, const double delta) override {
         if(this->_initialized == false) return;
         if(this->_active == false) return;
         this->emit_signal("cubism_epilogue", model->_owner_viewport, delta);

--- a/src/gd_cubism_effect_eye_blink.hpp
+++ b/src/gd_cubism_effect_eye_blink.hpp
@@ -55,7 +55,7 @@ public:
         this->_initialized = false;
     }
 
-    virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
+    virtual void _cubism_process(InternalCubismUserModel* model, const double delta) override {
         if(this->_initialized == false) return;
         if(this->_active == false) return;
         if(this->_eye_blink == nullptr) return;

--- a/src/gd_cubism_effect_hit_area.hpp
+++ b/src/gd_cubism_effect_hit_area.hpp
@@ -165,7 +165,7 @@ public:
         this->_initialized = false;
     }
 
-    virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
+    virtual void _cubism_process(InternalCubismUserModel* model, const double delta) override {
         if(this->_initialized == false) return;
         if(this->_active == false) return;
 

--- a/src/gd_cubism_effect_target_point.hpp
+++ b/src/gd_cubism_effect_target_point.hpp
@@ -170,7 +170,7 @@ public:
         this->_initialized = false;
     }
 
-    virtual void _cubism_process(InternalCubismUserModel* model, const float delta) override {
+    virtual void _cubism_process(InternalCubismUserModel* model, const double delta) override {
         if(this->_initialized == false) return;
         if(this->_active == false) return;
         if(this->_target_point == nullptr) return;

--- a/src/gd_cubism_user_model.cpp
+++ b/src/gd_cubism_user_model.cpp
@@ -450,7 +450,7 @@ void GDCubismUserModel::on_motion_finished(Csm::ACubismMotion* motion) {
 }
 
 
-void GDCubismUserModel::_update(const float delta) {
+void GDCubismUserModel::_update(const double delta) {
 
     this->internal_model->pro_update(delta * this->speed_scale);
 
@@ -493,7 +493,7 @@ void GDCubismUserModel::_update(const float delta) {
 }
 
 
-void GDCubismUserModel::advance(const float delta) {
+void GDCubismUserModel::advance(const double delta) {
     ERR_FAIL_COND(this->is_initialized() == false);
     if(this->playback_process_mode != MANUAL) return;
 

--- a/src/gd_cubism_user_model.hpp
+++ b/src/gd_cubism_user_model.hpp
@@ -221,9 +221,9 @@ public:
     // for Signal
     static void on_motion_finished(Csm::ACubismMotion* motion);
 
-    void _update(const float delta);
+    void _update(const double delta);
 
-    void advance(const float delta);
+    void advance(const double delta);
 
     bool check_cubism_effect_dirty() const;
     void cubism_effect_dirty_reset();

--- a/src/private/internal_cubism_user_model.cpp
+++ b/src/private/internal_cubism_user_model.cpp
@@ -172,7 +172,7 @@ void InternalCubismUserModel::model_load_resource()
 }
 
 
-void InternalCubismUserModel::pro_update(const float delta) {
+void InternalCubismUserModel::pro_update(const double delta) {
     if(this->IsInitialized() == false) return;
     if(this->_model_setting == nullptr) return;
     if(this->_model == nullptr) return;
@@ -193,7 +193,7 @@ void InternalCubismUserModel::pro_update(const float delta) {
 }
 
 
-void InternalCubismUserModel::efx_update(const float delta) {
+void InternalCubismUserModel::efx_update(const double delta) {
     if(this->IsInitialized() == false) return;
     if(this->_model_setting == nullptr) return;
     if(this->_model == nullptr) return;
@@ -208,7 +208,7 @@ void InternalCubismUserModel::efx_update(const float delta) {
 }
 
 
-void InternalCubismUserModel::epi_update(const float delta) {
+void InternalCubismUserModel::epi_update(const double delta) {
     if(this->IsInitialized() == false) return;
     if(this->_model_setting == nullptr) return;
     if(this->_model == nullptr) return;
@@ -479,7 +479,7 @@ void InternalCubismUserModel::effect_term() {
 }
 
 
-void InternalCubismUserModel::effect_batch(const float delta, const EFFECT_CALL efx_call) {
+void InternalCubismUserModel::effect_batch(const double delta, const EFFECT_CALL efx_call) {
     for(
         Csm::csmVector<GDCubismEffect*>::iterator i = this->_owner_viewport->_list_cubism_effect.Begin();
         i != this->_owner_viewport->_list_cubism_effect.End();

--- a/src/private/internal_cubism_user_model.hpp
+++ b/src/private/internal_cubism_user_model.hpp
@@ -63,9 +63,9 @@ private:
 public:
     bool model_load(const String &model_pathname);
     void model_load_resource();
-    void pro_update(const float delta);
-    void efx_update(const float delta);
-    void epi_update(const float delta);
+    void pro_update(const double delta);
+    void efx_update(const double delta);
+    void epi_update(const double delta);
     void update_node();
     void clear();
 
@@ -88,7 +88,7 @@ private:
 
     void effect_init();
     void effect_term();
-    void effect_batch(const float delta, const EFFECT_CALL efx_call);
+    void effect_batch(const double delta, const EFFECT_CALL efx_call);
 };
 
 


### PR DESCRIPTION
**Fix for Incorrect Data Type in Elapsed Time Representation**

The values passed from the **Godot Engine** via `_process` and `_physics_process` are of type `double`, but in **GDCubism**, they were being handled as `float`.

> in node.hpp (Godot Engine)
```c++
virtual void _process(double p_delta);
virtual void _physics_process(double p_delta);
```

While these values represent the elapsed time since the previous frame, and it is unlikely for them to exceed the precision of `float`, some implementations that distinguish between `float` and `double` may produce warnings.

To eliminate these warnings, the data type has been standardized to `double`.
